### PR TITLE
Use printf to write secrets without trailing newline

### DIFF
--- a/scripts/firebase-env.sh
+++ b/scripts/firebase-env.sh
@@ -273,8 +273,8 @@ create_temp_secret_files() {
     local secret_id="${SECRET_IDS[$i]}"
     local temp_file="$temp_dir/$secret_id.txt"
     
-    # Write the environment variable value to a temporary file
-    echo "${!envvar}" > "$temp_file"
+    # Write the environment variable value to a temporary file (no trailing newline)
+    printf '%s' "${!envvar}" > "$temp_file"
     log_info "Created temporary file: $temp_file"
   done
 }


### PR DESCRIPTION
resolves https://github.com/F3-Nation/pax-vault/issues/9

<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

Fixed a bug where Firebase secret files were being created with trailing newlines by replacing `echo` with `printf` in the secret creation script.

### 🔎 Details

The `create_temp_secret_files` function in `scripts/firebase-env.sh` was using `echo` to write environment variable values to temporary files. The `echo` command automatically appends a newline character to its output, which could cause issues when these secrets are used by systems that expect exact string values without trailing newlines.

Changed from:
echo "${!envvar}" > "$temp_file"

To:
printf '%s' "${!envvar}" > "$temp_file"

The `printf` command with `%s` format specifier writes the exact string content without adding any trailing newline, ensuring secret values are stored exactly as they appear in the environment variables.

### ✅ How to Test

1. **Verify the script change:**
   - Review the diff to ensure `echo` was replaced with `printf '%s'`
   - Confirm the comment was updated to reflect the change

2. **Test secret file creation:**
   - Run the `create_temp_secret_files` function with test environment variables
   - Check that created temporary files contain exactly the secret values without trailing newlines
   - Use `cat -A` or `od -c` to verify no newline characters are present at the end of files

3. **Integration test:**
   - If possible, test the full Firebase deployment flow that uses these secret files
   - Verify secrets are correctly consumed by downstream systems without newline-related issues

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
