### PR TITLE
Update runConfig for minimum instances and memory

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -1,11 +1,11 @@
 # Settings for Backend (on Cloud Run).
 # See https://firebase.google.com/docs/app-hosting/configure#cloud-run
 runConfig:
-  minInstances: 0
+  minInstances: 1
+  memoryMiB: 2048
   # maxInstances: 100
   # concurrency: 80
   # cpu: 1
-  # memoryMiB: 512
 
 # Environment variables and secrets.
 env:


### PR DESCRIPTION
Increased minimum instances from 0 to 1 and set memory to 2048 MiB. Starting to see slowness and low memory alerts. F3 is all in on PAX Vault!


