### PR TITLE
hotfix pax-vault auth

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -15,6 +15,14 @@ interface StatePayload {
   timestamp: number;
 }
 
+function getPublicOrigin(request: NextRequest): string {
+  const proto = request.headers.get("x-forwarded-proto") || "https";
+  const host =
+    request.headers.get("x-forwarded-host") || request.headers.get("host");
+  if (host) return `${proto}://${host}`;
+  return request.nextUrl.origin;
+}
+
 function errorRedirect(baseUrl: string, error: string, returnTo?: string) {
   const url = new URL("/", baseUrl);
   url.searchParams.set("error", error);
@@ -27,7 +35,7 @@ export async function GET(request: NextRequest) {
   const code = searchParams.get("code");
   const stateParam = searchParams.get("state");
   const errorParam = searchParams.get("error");
-  const baseUrl = request.nextUrl.origin;
+  const baseUrl = getPublicOrigin(request);
 
   if (errorParam) {
     return errorRedirect(baseUrl, errorParam);


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

Related to https://github.com/F3-Nation/f3-nation-auth/issues/39

### 👋 TL;DR

**Hotfix:** Fixes a production auth outage on https://pax-vault.f3nation.com by updating OAuth callback redirects to use the public origin instead of the internal application origin.

### 🔎 Details

Production auth at https://pax-vault.f3nation.com was broken because the OAuth callback endpoint was constructing redirect URLs using the internal Cloud Run application origin (e.g., `*.run.app`) rather than the public-facing origin (`pax-vault.f3nation.com`). This caused the OAuth flow to fail since the redirect URL didn't match the registered callback, breaking all user authentication.

This hotfix ensures redirects use the correct public origin, restoring auth functionality for all pax-vault users.

### ✅ How to Test

1. **Production verification:**
   - Visit https://pax-vault.f3nation.com
   - Trigger OAuth login flow
   - Verify the callback redirects to the correct `pax-vault.f3nation.com` origin and auth completes successfully

2. **Regression testing:**
   - Ensure existing OAuth flows continue to work correctly
   - Verify all necessary search parameters are preserved in redirects

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
