### PR TITLE
Auth redirect

### DIFF
--- a/src/app/api/ao/list/route.ts
+++ b/src/app/api/ao/list/route.ts
@@ -1,13 +1,13 @@
 /****
- * User list search API route.
+ * AO list search API route.
  *
  * Responsibilities:
  * - Parse and validate the search query parameter.
  * - Guard against overly-broad searches.
- * - Delegate user search to the BigQuery layer.
+ * - Delegate AO search to the BigQuery layer.
  */
 import { NextResponse } from "next/server";
-import { searchUsersByName } from "@/lib/bq/pax";
+import { searchAOsByName } from "@/lib/bq/aos";
 import { getSessionUser } from "@/lib/auth/server";
 
 export async function GET(request: Request) {
@@ -25,16 +25,13 @@ export async function GET(request: Request) {
     return NextResponse.json([], { status: 200 });
   }
 
-  const rawRegionId = searchParams.get("region_id");
-  const regionId = rawRegionId !== null ? parseInt(rawRegionId, 10) : undefined;
-
   try {
-    const users = await searchUsersByName(q, user.email, regionId);
-    return NextResponse.json(users, { status: 200 });
+    const aos = await searchAOsByName(q, user.email);
+    return NextResponse.json(aos, { status: 200 });
   } catch (err) {
-    console.error("Pax search failed:", err);
+    console.error("AO search failed:", err);
     return NextResponse.json(
-      { error: "Pax search failed. Please try again." },
+      { error: "AO search failed. Please try again." },
       { status: 500 },
     );
   }

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { exchangeCodeForToken, getUserInfo } from "@/lib/auth/oauth";
 import { isAuthorizedEmail } from "@/lib/auth/allowlist";
+import { getPaxIdByEmail } from "@/lib/bq/pax";
 import { createSessionValue } from "@/lib/auth/session";
 import {
   SESSION_COOKIE_MAX_AGE,
@@ -108,6 +109,19 @@ export async function GET(request: NextRequest) {
     return errorRedirect(baseUrl, "allowlist_error", returnTo);
   }
 
+  // If no explicit returnTo was requested, redirect to the user's own PAX page
+  let effectiveReturnTo = returnTo;
+  if (returnTo === "/stats/nation") {
+    try {
+      const paxId = await getPaxIdByEmail(userInfo.email, userInfo.email);
+      if (paxId != null) {
+        effectiveReturnTo = `/stats/pax/${paxId}`;
+      }
+    } catch (err) {
+      console.error("PAX id lookup failed, falling back to default", err);
+    }
+  }
+
   // Create HMAC session cookie
   const sessionValue = createSessionValue({
     sub: userInfo.sub,
@@ -115,7 +129,9 @@ export async function GET(request: NextRequest) {
     name: userInfo.name,
   });
 
-  const response = NextResponse.redirect(new URL(returnTo, baseUrl).toString());
+  const response = NextResponse.redirect(
+    new URL(effectiveReturnTo, baseUrl).toString(),
+  );
 
   response.cookies.set(SESSION_COOKIE_NAME, sessionValue, {
     httpOnly: true,

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTheme } from "next-themes";
 import { Navbar, NavbarBrand, NavbarContent, NavbarItem } from "@heroui/navbar";
 import { Link } from "@heroui/link";
-import { Autocomplete, AutocompleteItem } from "@heroui/autocomplete";
-import { Avatar } from "@heroui/avatar";
 import { Button } from "@heroui/button";
 import {
   Dropdown,
@@ -14,149 +12,16 @@ import {
   DropdownMenu,
   DropdownTrigger,
 } from "@heroui/dropdown";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerHeader,
-  DrawerBody,
-} from "@heroui/drawer";
 import { Modal, ModalBody, ModalContent, ModalHeader } from "@heroui/modal";
 import { useDisclosure } from "@heroui/use-disclosure";
-import { Divider } from "@heroui/divider";
-import { RegionInfo, PAXInfo } from "@/lib/types";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { MoonIcon, SunIcon } from "@/components/icons";
+import SearchModal from "@/components/search-modal";
 
 type BeforeInstallPromptEvent = Event & {
   prompt: () => Promise<void>;
   userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
 };
-
-/**
- * Small helper for debounced, client-side search against a JSON endpoint.
- *
- * Design goals:
- * - Avoid duplicated useEffect/fetch boilerplate for each search box.
- * - Provide consistent loading/error semantics.
- * - Protect against state updates after unmount.
- */
-type DebouncedSearchArgs<T> = {
-  input: string;
-  minChars?: number;
-  delayMs?: number;
-  urlForQuery: (q: string) => string;
-  setData: (data: T[]) => void;
-  setApiLoading: (v: boolean) => void;
-  setApiError: (v: string | null) => void;
-  setTypingLoading: (v: boolean) => void;
-  validate?: (data: unknown) => data is T[];
-};
-
-function useDebouncedApiSearch<T>({
-  input,
-  minChars = 2,
-  delayMs = 1000,
-  urlForQuery,
-  setData,
-  setApiLoading,
-  setApiError,
-  setTypingLoading,
-  validate,
-}: DebouncedSearchArgs<T>) {
-  useEffect(() => {
-    let isMounted = true;
-
-    const q = input.trim();
-    if (q.length < minChars) {
-      setData([]);
-      setApiLoading(false);
-      setApiError(null);
-      setTypingLoading(false);
-      return;
-    }
-
-    // Show spinner while user is actively searching.
-    setApiLoading(true);
-    setApiError(null);
-
-    const t = setTimeout(async () => {
-      try {
-        const res = await fetch(urlForQuery(q), {
-          method: "GET",
-          headers: { Accept: "application/json" },
-        });
-
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          throw new Error(body?.error || `Request failed: ${res.status}`);
-        }
-
-        const data = (await res.json()) as unknown;
-        const ok = validate ? validate(data) : Array.isArray(data);
-        if (!ok) {
-          throw new Error("Search endpoint did not return an array");
-        }
-
-        if (isMounted) setData(data as T[]);
-        if (isMounted) setTypingLoading(false);
-        if (isMounted) setApiLoading(false);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : "Unknown error";
-        if (isMounted) {
-          setApiError(message);
-          setTypingLoading(false);
-          setApiLoading(false);
-        }
-      }
-    }, delayMs);
-
-    return () => {
-      isMounted = false;
-      clearTimeout(t);
-    };
-  }, [
-    input,
-    minChars,
-    delayMs,
-    urlForQuery,
-    setData,
-    setApiLoading,
-    setApiError,
-    setTypingLoading,
-    validate,
-  ]);
-}
-
-/**
- * Build a consistent selection handler for autocomplete navigation.
- *
- * Note: HeroUI passes the selected key, or the string "null" in some cases.
- */
-function makeNavSelectionHandler(args: {
-  routeForKey: (key: React.Key) => string;
-  setKey: (k: React.Key | null) => void;
-  clearInput: () => void;
-  onAfterNavigate?: () => void;
-  routerPush: (href: string) => void;
-}) {
-  const { routeForKey, setKey, clearInput, onAfterNavigate, routerPush } = args;
-
-  return (key: React.Key | null) => {
-    setKey(key);
-
-    // HeroUI sometimes provides the literal string "null".
-    if (!key || key === "null") return;
-
-    routerPush(routeForKey(key));
-
-    // Small delay ensures the Autocomplete closes cleanly before we reset state.
-    setTimeout(() => {
-      clearInput();
-      setKey(null);
-      onAfterNavigate?.();
-    }, 100);
-  };
-}
 
 // --- Inline SVG icon components for Sign in / Sign out ---
 function SignInIcon(props: React.SVGProps<SVGSVGElement>) {
@@ -325,9 +190,9 @@ export default function NavbarClient() {
   const { user, loading: authLoading, signOut } = useAuth();
   const isAuthed = !!user;
   const {
-    isOpen: isDrawerOpen,
-    onOpen: onDrawerOpen,
-    onOpenChange: onDrawerOpenChange,
+    isOpen: isSearchOpen,
+    onOpen: onSearchOpen,
+    onOpenChange: onSearchOpenChange,
   } = useDisclosure();
   const {
     isOpen: isInstallOpen,
@@ -341,145 +206,6 @@ export default function NavbarClient() {
   const [isIOS, setIsIOS] = useState(false);
   const [themeMounted, setThemeMounted] = useState(false);
   const { resolvedTheme, setTheme } = useTheme();
-
-  // --- Search state (shared pattern: input -> debounced API -> options -> selection navigates) ---
-
-  // Pax search state
-  const [paxData, setPaxData] = useState<PAXInfo[]>([]);
-  const [paxApiLoading, setPaxApiLoading] = useState(false);
-  const [paxApiError, setPaxApiError] = useState<string | null>(null);
-  const [paxKey, setPaxKey] = useState<React.Key | null>(null);
-  const [paxLoading, setPaxLoading] = useState(false);
-  const [paxInput, setPaxInput] = useState<string>("");
-
-  // Region search state
-  const [regionData, setRegionData] = useState<RegionInfo[]>([]);
-  const [regionApiLoading, setRegionApiLoading] = useState(false);
-  const [regionApiError, setRegionApiError] = useState<string | null>(null);
-  const [regionKey, setRegionKey] = useState<React.Key | null>(null);
-  const [regionLoading, setRegionLoading] = useState(false);
-  const [regionInput, setRegionInput] = useState<string>("");
-
-  // Memoize helpers so the debounced search hook doesn't re-run on every render.
-  // Inline arrow functions are new references each render and can cause an effect loop
-  // because the hook sets state inside its effect.
-  const regionUrlForQuery = useCallback(
-    (q: string) => `/api/region/list/?q=${encodeURIComponent(q)}`,
-    [],
-  );
-
-  const paxUrlForQuery = useCallback(
-    (q: string) => `/api/pax/list/?q=${encodeURIComponent(q)}`,
-    [],
-  );
-
-  const validateArray = useCallback(
-    (data: unknown): data is unknown[] => Array.isArray(data),
-    [],
-  );
-  const validateRegionData = useCallback(
-    (data: unknown): data is RegionInfo[] => validateArray(data),
-    [validateArray],
-  );
-  const validatePaxData = useCallback(
-    (data: unknown): data is PAXInfo[] => validateArray(data),
-    [validateArray],
-  );
-
-  // Debounced region search (calls /api/region/list?q=...)
-  useDebouncedApiSearch<RegionInfo>({
-    input: regionInput,
-    urlForQuery: regionUrlForQuery,
-    setData: setRegionData,
-    setApiLoading: setRegionApiLoading,
-    setApiError: setRegionApiError,
-    setTypingLoading: setRegionLoading,
-    validate: validateRegionData,
-  });
-
-  // Debounced pax search (calls /api/users?q=...)
-  useDebouncedApiSearch<PAXInfo>({
-    input: paxInput,
-    urlForQuery: paxUrlForQuery,
-    setData: setPaxData,
-    setApiLoading: setPaxApiLoading,
-    setApiError: setPaxApiError,
-    setTypingLoading: setPaxLoading,
-    validate: validatePaxData,
-  });
-
-  // Defensive filtering: Autocomplete expects items with displayable names.
-  const paxOptions = useMemo(
-    () => paxData.filter((p) => p && p.f3_name),
-    [paxData],
-  );
-
-  // Defensive filtering: Autocomplete expects items with displayable names.
-  const regionOptions = useMemo(
-    () => regionData.filter((r) => r && r.region_name),
-    [regionData],
-  );
-
-  // Handle pax input change with loading
-  const handlePaxInputChange = (value: string) => {
-    setPaxInput(value);
-    // Typing spinner is a UI hint; the effect will clear it when results arrive.
-    setPaxLoading(value.trim().length > 0);
-  };
-
-  // Handle region input change with loading
-  const handleRegionInputChange = (value: string) => {
-    setRegionInput(value);
-    // Typing spinner is a UI hint; the effect will clear it when results arrive.
-    setRegionLoading(value.trim().length > 0);
-  };
-
-  // Navigation handlers (desktop/mobile share behavior; mobile also closes the drawer).
-  const handlePaxSelection = useMemo(
-    () =>
-      makeNavSelectionHandler({
-        routeForKey: (key) => `/stats/pax/${key}`,
-        setKey: setPaxKey,
-        clearInput: () => setPaxInput(""),
-        routerPush: router.push,
-      }),
-    [router.push],
-  );
-
-  const handlePaxSelectionMobile = useMemo(
-    () =>
-      makeNavSelectionHandler({
-        routeForKey: (key) => `/stats/pax/${key}`,
-        setKey: setPaxKey,
-        clearInput: () => setPaxInput(""),
-        onAfterNavigate: () => onDrawerOpenChange(),
-        routerPush: router.push,
-      }),
-    [router.push, onDrawerOpenChange],
-  );
-
-  const handleRegionSelection = useMemo(
-    () =>
-      makeNavSelectionHandler({
-        routeForKey: (key) => `/stats/region/${key}`,
-        setKey: setRegionKey,
-        clearInput: () => setRegionInput(""),
-        routerPush: router.push,
-      }),
-    [router.push],
-  );
-
-  const handleRegionSelectionMobile = useMemo(
-    () =>
-      makeNavSelectionHandler({
-        routeForKey: (key) => `/stats/region/${key}`,
-        setKey: setRegionKey,
-        clearInput: () => setRegionInput(""),
-        onAfterNavigate: () => onDrawerOpenChange(),
-        routerPush: router.push,
-      }),
-    [router.push, onDrawerOpenChange],
-  );
 
   const handleSignIn = useCallback(() => {
     router.push("/#signin");
@@ -511,6 +237,7 @@ export default function NavbarClient() {
     );
   }, []);
 
+  // PWA install detection + Cmd/Ctrl+K shortcut to open search.
   useEffect(() => {
     setThemeMounted(true);
     const nav = window.navigator as Navigator & { standalone?: boolean };
@@ -535,14 +262,23 @@ export default function NavbarClient() {
       setPwaPrompt(null);
     };
 
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        onSearchOpen();
+      }
+    };
+
     window.addEventListener("beforeinstallprompt", handleBeforeInstall);
     window.addEventListener("appinstalled", handleInstalled);
+    window.addEventListener("keydown", handleKeyDown);
 
     return () => {
       window.removeEventListener("beforeinstallprompt", handleBeforeInstall);
       window.removeEventListener("appinstalled", handleInstalled);
+      window.removeEventListener("keydown", handleKeyDown);
     };
-  }, []);
+  }, [onSearchOpen]);
 
   const showInstallAction = (Boolean(pwaPrompt) || isIOS) && !pwaInstalled;
   const isDark = themeMounted && resolvedTheme === "dark";
@@ -629,226 +365,46 @@ export default function NavbarClient() {
         </NavbarBrand>
       </NavbarContent>
 
-      {/* Desktop Search Fields */}
+      {/* Desktop — single search button */}
       <NavbarContent className="hidden lg:flex" justify="end">
         {isAuthed && (
-          <>
-            <NavbarItem className="w-64">
-              <Autocomplete
-                className="w-full"
-                label="SEARCH FOR A REGION"
-                defaultItems={regionOptions}
-                inputValue={regionInput}
-                isLoading={regionLoading || regionApiLoading}
-                itemHeight={40}
-                selectedKey={regionKey !== null ? String(regionKey) : null}
-                onInputChange={handleRegionInputChange}
-                onSelectionChange={handleRegionSelection}
-                variant="bordered"
-                color="primary"
-                size="sm"
-                isClearable
-              >
-                {(region) => (
-                  <AutocompleteItem
-                    key={region.region_id}
-                    textValue={region.region_name}
-                  >
-                    <div className="flex gap-2 items-center">
-                      <Avatar
-                        alt={region.region_name}
-                        className="flex-shrink-0"
-                        size="sm"
-                        src={region.logo_url ?? undefined}
-                      />
-                      <div className="flex flex-col">
-                        <span className="text-small">{region.region_name}</span>
-                      </div>
-                    </div>
-                  </AutocompleteItem>
-                )}
-              </Autocomplete>
-              {regionApiError && (
-                <div className="mt-1 text-tiny text-danger-500">
-                  {regionApiError}
-                </div>
-              )}
-            </NavbarItem>
-
-            <NavbarItem className="w-64">
-              <Autocomplete
-                className="w-full"
-                label="SEARCH FOR A PAX"
-                defaultItems={paxOptions}
-                inputValue={paxInput}
-                isLoading={paxLoading || paxApiLoading}
-                itemHeight={40}
-                selectedKey={paxKey !== null ? String(paxKey) : null}
-                onInputChange={handlePaxInputChange}
-                onSelectionChange={handlePaxSelection}
-                variant="bordered"
-                color="primary"
-                size="sm"
-                isClearable
-              >
-                {(pax) => (
-                  <AutocompleteItem key={pax.user_id} textValue={pax.f3_name}>
-                    <div className="flex gap-2 items-center">
-                      <Avatar
-                        alt={pax.f3_name}
-                        className="flex-shrink-0"
-                        size="sm"
-                        src={pax.avatar_url ?? undefined}
-                      />
-                      <div className="flex flex-col">
-                        <span className="text-small">
-                          {pax.f3_name && pax.f3_name.length > 20
-                            ? pax.f3_name.slice(0, 20) + "..."
-                            : pax.f3_name || "Unknown PAX"}
-                        </span>
-                        <span className="text-tiny text-default-400">
-                          {pax.home_region_name || "Unknown Region"}
-                        </span>
-                      </div>
-                    </div>
-                  </AutocompleteItem>
-                )}
-              </Autocomplete>
-              {paxApiError && (
-                <div className="mt-1 text-tiny text-danger-500">
-                  {paxApiError}
-                </div>
-              )}
-            </NavbarItem>
-          </>
+          <NavbarItem>
+            <Button
+              variant="bordered"
+              color="primary"
+              size="sm"
+              onPress={onSearchOpen}
+            >
+              SEARCH
+            </Button>
+          </NavbarItem>
         )}
         <NavbarItem>{renderActionMenu("lg")}</NavbarItem>
       </NavbarContent>
 
-      {/* Mobile Search Buttons */}
+      {/* Mobile — single search button */}
       <NavbarContent className="flex lg:hidden" justify="end">
         {isAuthed && (
           <NavbarItem>
             <Button
-              key="search-region-pax"
-              className="w-40"
               variant="bordered"
               color="primary"
               size="sm"
-              onPress={() => onDrawerOpen()}
+              onPress={onSearchOpen}
             >
-              FIND REGION OR PAX
+              SEARCH
             </Button>
           </NavbarItem>
         )}
         <NavbarItem>{renderActionMenu("sm")}</NavbarItem>
       </NavbarContent>
 
+      {/* Unified search modal */}
       {isAuthed && (
-        <Drawer
-          isOpen={isDrawerOpen}
-          key={isDrawerOpen ? "mobile_open" : "mobile_closed"}
-          backdrop="blur"
-          placement="top"
-          classNames={{
-            wrapper: "h-full",
-          }}
-          onOpenChange={onDrawerOpenChange}
-          isDismissable={false}
-          isKeyboardDismissDisabled={true}
-        >
-          <DrawerContent>
-            <DrawerHeader className="flex flex-col gap-1">
-              SEARCH FOR A REGION OR A PAX
-            </DrawerHeader>
-            <Divider />
-            <DrawerBody className="flex flex-col gap-10 py-10">
-              <Autocomplete
-                className="w-full"
-                label="SEARCH FOR A REGION"
-                defaultItems={regionOptions}
-                inputValue={regionInput}
-                isLoading={regionLoading || regionApiLoading}
-                itemHeight={40}
-                selectedKey={String(regionKey) ?? null}
-                onInputChange={handleRegionInputChange}
-                onSelectionChange={handleRegionSelectionMobile}
-                variant="bordered"
-                size="lg"
-                color="primary"
-                isClearable
-              >
-                {(region) => (
-                  <AutocompleteItem
-                    key={region.region_id}
-                    textValue={region.region_name}
-                  >
-                    <div className="flex gap-2 items-center">
-                      <Avatar
-                        alt={region.region_name}
-                        className="flex-shrink-0"
-                        size="sm"
-                        src={region.logo_url ?? undefined}
-                      />
-                      <div className="flex flex-col">
-                        <span className="text-small">{region.region_name}</span>
-                      </div>
-                    </div>
-                  </AutocompleteItem>
-                )}
-              </Autocomplete>
-              {regionApiError && (
-                <div className="mt-1 text-tiny text-danger-500">
-                  {regionApiError}
-                </div>
-              )}
-              <Autocomplete
-                className="w-full"
-                label="SEARCH FOR A PAX"
-                defaultItems={paxOptions}
-                inputValue={paxInput}
-                isLoading={paxLoading || paxApiLoading}
-                itemHeight={40}
-                selectedKey={String(paxKey) ?? null}
-                onInputChange={handlePaxInputChange}
-                onSelectionChange={handlePaxSelectionMobile}
-                variant="bordered"
-                size="lg"
-                color="primary"
-                isClearable
-              >
-                {(pax) => (
-                  <AutocompleteItem key={pax.user_id} textValue={pax.f3_name}>
-                    <div className="flex gap-2 items-center">
-                      <Avatar
-                        alt={pax.f3_name}
-                        className="flex-shrink-0"
-                        size="sm"
-                        src={pax.avatar_url ?? undefined}
-                      />
-                      <div className="flex flex-col">
-                        <span className="text-small">
-                          {pax.f3_name && pax.f3_name.length > 20
-                            ? pax.f3_name.slice(0, 20) + "..."
-                            : pax.f3_name || "Unknown PAX"}
-                        </span>
-                        <span className="text-tiny text-default-400">
-                          {pax.home_region_name || "Unknown Region"}
-                        </span>
-                      </div>
-                    </div>
-                  </AutocompleteItem>
-                )}
-              </Autocomplete>
-              {paxApiError && (
-                <div className="mt-1 text-tiny text-danger-500">
-                  {paxApiError}
-                </div>
-              )}
-            </DrawerBody>
-          </DrawerContent>
-        </Drawer>
+        <SearchModal isOpen={isSearchOpen} onOpenChange={onSearchOpenChange} />
       )}
+
+      {/* PWA install modal (iOS instructions) */}
       <Modal
         isOpen={isInstallOpen}
         onOpenChange={onInstallOpenChange}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -371,8 +371,8 @@ export default function NavbarClient() {
           <NavbarItem>
             <Button
               variant="bordered"
-              color="primary"
-              size="sm"
+              color="default"
+              size="md"
               onPress={onSearchOpen}
             >
               SEARCH
@@ -388,7 +388,7 @@ export default function NavbarClient() {
           <NavbarItem>
             <Button
               variant="bordered"
-              color="primary"
+              color="default"
               size="sm"
               onPress={onSearchOpen}
             >

--- a/src/components/search-modal.tsx
+++ b/src/components/search-modal.tsx
@@ -1,0 +1,541 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Modal, ModalContent, ModalBody } from "@heroui/modal";
+import { Input } from "@heroui/input";
+import { Avatar } from "@heroui/avatar";
+import { Spinner } from "@heroui/spinner";
+import { PAXInfo, RegionInfo, AOInfo } from "@/lib/types";
+
+type SearchModalProps = {
+  isOpen: boolean;
+  onOpenChange: () => void;
+};
+
+type SearchResult =
+  | { kind: "pax"; item: PAXInfo }
+  | { kind: "region"; item: RegionInfo }
+  | { kind: "ao"; item: AOInfo };
+
+function routeForResult(result: SearchResult): string {
+  switch (result.kind) {
+    case "pax":
+      return `/stats/pax/${result.item.user_id}`;
+    case "region":
+      return `/stats/region/${result.item.region_id}`;
+    case "ao":
+      return `/stats/ao/${result.item.ao_id}`;
+  }
+}
+
+async function fetchJson<T>(url: string): Promise<T[]> {
+  const res = await fetch(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { error?: string }).error || `Request failed: ${res.status}`,
+    );
+  }
+  const data = await res.json();
+  if (!Array.isArray(data)) throw new Error("Unexpected response format");
+  return data as T[];
+}
+
+const SECTION_IDS = {
+  regions: "search-section-regions",
+  aos: "search-section-aos",
+  pax: "search-section-pax",
+} as const;
+
+export default function SearchModal({
+  isOpen,
+  onOpenChange,
+}: SearchModalProps) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [paxResults, setPaxResults] = useState<PAXInfo[]>([]);
+  const [regionResults, setRegionResults] = useState<RegionInfo[]>([]);
+  const [aoResults, setAoResults] = useState<AOInfo[]>([]);
+  const [paxLoading, setPaxLoading] = useState(false);
+  const [regionLoading, setRegionLoading] = useState(false);
+  const [aoLoading, setAoLoading] = useState(false);
+  const [paxError, setPaxError] = useState<string | null>(null);
+  const [regionError, setRegionError] = useState<string | null>(null);
+  const [aoError, setAoError] = useState<string | null>(null);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // Flatten all results into a single ordered list for keyboard nav.
+  // Order: Regions → AOs → PAX
+  const allResults = useMemo<SearchResult[]>(() => {
+    const items: SearchResult[] = [];
+    for (const r of regionResults) items.push({ kind: "region", item: r });
+    for (const a of aoResults) items.push({ kind: "ao", item: a });
+    for (const p of paxResults) items.push({ kind: "pax", item: p });
+    return items;
+  }, [regionResults, aoResults, paxResults]);
+
+  const isLoading = paxLoading || regionLoading || aoLoading;
+  const hasQuery = query.trim().length >= 2;
+  const hasResults = allResults.length > 0;
+
+  // Which jump-to links to show (only sections that have results).
+  const jumpLinks = useMemo(() => {
+    const links: { label: string; id: string }[] = [];
+    if (regionResults.length > 0)
+      links.push({ label: "Regions", id: SECTION_IDS.regions });
+    if (aoResults.length > 0) links.push({ label: "AOs", id: SECTION_IDS.aos });
+    if (paxResults.length > 0)
+      links.push({ label: "PAX", id: SECTION_IDS.pax });
+    return links;
+  }, [regionResults.length, aoResults.length, paxResults.length]);
+
+  const scrollToSection = useCallback((sectionId: string) => {
+    const container = scrollContainerRef.current;
+    const section = document.getElementById(sectionId);
+    if (!container || !section) return;
+    container.scrollTop = section.offsetTop - container.offsetTop;
+  }, []);
+
+  // Reset state when modal opens/closes.
+  useEffect(() => {
+    if (!isOpen) {
+      setQuery("");
+      setPaxResults([]);
+      setRegionResults([]);
+      setAoResults([]);
+      setPaxError(null);
+      setRegionError(null);
+      setAoError(null);
+      setFocusedIndex(-1);
+    }
+  }, [isOpen]);
+
+  // Debounced search — fires 3 parallel fetches.
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 2) {
+      setPaxResults([]);
+      setRegionResults([]);
+      setAoResults([]);
+      setPaxLoading(false);
+      setRegionLoading(false);
+      setAoLoading(false);
+      setPaxError(null);
+      setRegionError(null);
+      setAoError(null);
+      setFocusedIndex(-1);
+      return;
+    }
+
+    setPaxLoading(true);
+    setRegionLoading(true);
+    setAoLoading(true);
+    setFocusedIndex(-1);
+
+    let cancelled = false;
+    const encoded = encodeURIComponent(q);
+
+    const t = setTimeout(() => {
+      fetchJson<PAXInfo>(`/api/pax/list?q=${encoded}`)
+        .then((data) => {
+          if (!cancelled) setPaxResults(data);
+        })
+        .catch((err) => {
+          if (!cancelled)
+            setPaxError(err instanceof Error ? err.message : "Search failed");
+        })
+        .finally(() => {
+          if (!cancelled) setPaxLoading(false);
+        });
+
+      fetchJson<RegionInfo>(`/api/region/list?q=${encoded}`)
+        .then((data) => {
+          if (!cancelled) setRegionResults(data);
+        })
+        .catch((err) => {
+          if (!cancelled)
+            setRegionError(
+              err instanceof Error ? err.message : "Search failed",
+            );
+        })
+        .finally(() => {
+          if (!cancelled) setRegionLoading(false);
+        });
+
+      fetchJson<AOInfo>(`/api/ao/list?q=${encoded}`)
+        .then((data) => {
+          if (!cancelled) setAoResults(data);
+        })
+        .catch((err) => {
+          if (!cancelled)
+            setAoError(err instanceof Error ? err.message : "Search failed");
+        })
+        .finally(() => {
+          if (!cancelled) setAoLoading(false);
+        });
+    }, 600);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [query]);
+
+  const navigate = useCallback(
+    (result: SearchResult) => {
+      router.push(routeForResult(result));
+      onOpenChange();
+    },
+    [router, onOpenChange],
+  );
+
+  // Keyboard navigation.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setFocusedIndex((i) => Math.min(i + 1, allResults.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setFocusedIndex((i) => Math.max(i - 1, -1));
+      } else if (e.key === "Enter" && focusedIndex >= 0) {
+        e.preventDefault();
+        const result = allResults[focusedIndex];
+        if (result) navigate(result);
+      }
+    },
+    [allResults, focusedIndex, navigate],
+  );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      placement="top"
+      size="2xl"
+      backdrop="blur"
+      classNames={{
+        base: "mt-16",
+        body: "p-0",
+      }}
+      hideCloseButton
+    >
+      <ModalContent>
+        <ModalBody>
+          <div onKeyDown={handleKeyDown}>
+            {/* Search input */}
+            <div className="px-4 pt-4 pb-2">
+              <Input
+                ref={inputRef}
+                autoFocus
+                value={query}
+                onValueChange={setQuery}
+                placeholder="Search for PAX, regions, AOs..."
+                variant="bordered"
+                size="lg"
+                isClearable
+                onClear={() => setQuery("")}
+                startContent={
+                  isLoading ? (
+                    <Spinner size="sm" color="primary" />
+                  ) : (
+                    <SearchIcon className="h-4 w-4 text-default-400" />
+                  )
+                }
+              />
+            </div>
+
+            {/* Jump-to-section bar — only when multiple sections have results */}
+            {jumpLinks.length > 1 && (
+              <div className="flex items-center gap-1 px-4 pb-2 text-xs text-default-400">
+                <span className="mr-1">Jump to:</span>
+                {jumpLinks.map((link, i) => (
+                  <span key={link.id} className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      className="text-primary hover:underline cursor-pointer"
+                      onClick={() => scrollToSection(link.id)}
+                    >
+                      {link.label}
+                    </button>
+                    {i < jumpLinks.length - 1 && (
+                      <span className="text-default-300">·</span>
+                    )}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Results */}
+            <div
+              ref={scrollContainerRef}
+              className="max-h-[60vh] overflow-y-auto pb-4"
+            >
+              {!hasQuery && (
+                <div className="px-4 py-8 text-center text-sm text-default-400">
+                  Type at least 2 characters to search
+                </div>
+              )}
+
+              {hasQuery && !isLoading && !hasResults && (
+                <div className="px-4 py-8 text-center text-sm text-default-400">
+                  No results found
+                </div>
+              )}
+
+              {/* Regions section */}
+              <ResultSection
+                id={SECTION_IDS.regions}
+                title="REGIONS"
+                loading={regionLoading}
+                error={regionError}
+                empty={hasQuery && !regionLoading && regionResults.length === 0}
+              >
+                {regionResults.map((region) => {
+                  const idx = allResults.findIndex(
+                    (r) =>
+                      r.kind === "region" &&
+                      r.item.region_id === region.region_id,
+                  );
+                  return (
+                    <ResultItem
+                      key={region.region_id}
+                      isFocused={focusedIndex === idx}
+                      onMouseEnter={() => setFocusedIndex(idx)}
+                      onClick={() => navigate({ kind: "region", item: region })}
+                    >
+                      <Avatar
+                        alt={region.region_name}
+                        size="sm"
+                        src={region.logo_url ?? undefined}
+                        className="flex-shrink-0"
+                      />
+                      <div className="flex flex-col min-w-0">
+                        <span className="text-sm font-medium truncate">
+                          {region.region_name}
+                        </span>
+                      </div>
+                    </ResultItem>
+                  );
+                })}
+              </ResultSection>
+
+              {/* AOs section */}
+              <ResultSection
+                id={SECTION_IDS.aos}
+                title="AOs"
+                loading={aoLoading}
+                error={aoError}
+                empty={hasQuery && !aoLoading && aoResults.length === 0}
+                showDivider
+              >
+                {aoResults.map((ao) => {
+                  const idx = allResults.findIndex(
+                    (r) => r.kind === "ao" && r.item.ao_id === ao.ao_id,
+                  );
+                  return (
+                    <ResultItem
+                      key={ao.ao_id}
+                      isFocused={focusedIndex === idx}
+                      onMouseEnter={() => setFocusedIndex(idx)}
+                      onClick={() => navigate({ kind: "ao", item: ao })}
+                    >
+                      <Avatar
+                        alt={ao.ao_name}
+                        size="sm"
+                        src={ao.logo_url ?? undefined}
+                        className="flex-shrink-0"
+                      />
+                      <div className="flex flex-col min-w-0">
+                        <span className="text-sm font-medium truncate">
+                          {ao.ao_name}
+                        </span>
+                        <span className="text-xs text-default-400 truncate">
+                          {ao.region_name}
+                        </span>
+                      </div>
+                    </ResultItem>
+                  );
+                })}
+              </ResultSection>
+
+              {/* PAX section */}
+              <ResultSection
+                id={SECTION_IDS.pax}
+                title="PAX"
+                loading={paxLoading}
+                error={paxError}
+                empty={hasQuery && !paxLoading && paxResults.length === 0}
+                showDivider
+              >
+                {paxResults.map((pax) => {
+                  const idx = allResults.findIndex(
+                    (r) => r.kind === "pax" && r.item.user_id === pax.user_id,
+                  );
+                  return (
+                    <ResultItem
+                      key={pax.user_id}
+                      isFocused={focusedIndex === idx}
+                      onMouseEnter={() => setFocusedIndex(idx)}
+                      onClick={() => navigate({ kind: "pax", item: pax })}
+                    >
+                      <Avatar
+                        alt={pax.f3_name}
+                        size="sm"
+                        src={pax.avatar_url ?? undefined}
+                        className="flex-shrink-0"
+                      />
+                      <div className="flex flex-col min-w-0">
+                        <span className="text-sm font-medium truncate">
+                          {pax.f3_name || "Unknown PAX"}
+                        </span>
+                        <span className="text-xs text-default-400 truncate">
+                          {pax.home_region_name || "Unknown Region"}
+                        </span>
+                      </div>
+                    </ResultItem>
+                  );
+                })}
+              </ResultSection>
+            </div>
+
+            {/* Footer: keyboard hints */}
+            <div className="flex items-center gap-4 px-4 py-2 border-t border-divider text-xs text-default-400">
+              <span>
+                <kbd className="px-1 py-0.5 rounded bg-default-100 font-mono">
+                  ↑↓
+                </kbd>{" "}
+                navigate
+              </span>
+              <span>
+                <kbd className="px-1 py-0.5 rounded bg-default-100 font-mono">
+                  ↵
+                </kbd>{" "}
+                select
+              </span>
+              <span>
+                <kbd className="px-1 py-0.5 rounded bg-default-100 font-mono">
+                  esc
+                </kbd>{" "}
+                close
+              </span>
+            </div>
+
+            {/* Footer: duplicate PAX note */}
+            <div className="px-4 py-2 border-t border-divider text-xs text-default-400">
+              Seeing duplicate PAX results?{" "}
+              <a
+                href="https://docs.google.com/document/d/1e7tmuY3irKDt9oy1URQVcxPwxyet1ZY_bVZhGvhESEw/edit?tab=t.5anzgzo1iu9#heading=h.w93pdbdrmr21"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                Consult the FAQ guide on how to merge accounts.
+              </a>
+            </div>
+          </div>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+// --- Sub-components ---
+
+function ResultSection({
+  id,
+  title,
+  loading,
+  error,
+  empty,
+  showDivider = false,
+  children,
+}: {
+  id: string;
+  title: string;
+  loading: boolean;
+  error: string | null;
+  empty: boolean;
+  showDivider?: boolean;
+  children: React.ReactNode;
+}) {
+  const hasChildren = Array.isArray(children)
+    ? children.length > 0
+    : !!children;
+
+  if (!loading && !error && empty) return null;
+  if (!loading && !error && !hasChildren) return null;
+
+  return (
+    <div
+      id={id}
+      className={showDivider ? "border-t border-divider mt-1 pt-1" : "mt-2"}
+    >
+      <div className="px-4 py-1 text-xs font-semibold tracking-widest text-default-400 uppercase">
+        {title}
+      </div>
+      {error && (
+        <div className="px-4 py-2 text-xs text-danger-500">{error}</div>
+      )}
+      {loading && !hasChildren && (
+        <div className="flex items-center gap-2 px-4 py-3 text-xs text-default-400">
+          <Spinner size="sm" /> Searching...
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+function ResultItem({
+  isFocused,
+  onMouseEnter,
+  onClick,
+  children,
+}: {
+  isFocused: boolean;
+  onMouseEnter: () => void;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      className={`w-full flex items-center gap-3 px-4 py-2 text-left transition-colors cursor-pointer ${
+        isFocused
+          ? "bg-primary-50 dark:bg-primary-900/20"
+          : "hover:bg-default-100"
+      }`}
+      onMouseEnter={onMouseEnter}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+function SearchIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      {...props}
+    >
+      <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
+      <path
+        d="M16.5 16.5L21 21"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/search-modal.tsx
+++ b/src/components/search-modal.tsx
@@ -236,7 +236,7 @@ export default function SearchModal({
                 autoFocus
                 value={query}
                 onValueChange={setQuery}
-                placeholder="Search for PAX, regions, AOs..."
+                placeholder="Search for PAX, Regions, AOs..."
                 variant="bordered"
                 size="lg"
                 isClearable

--- a/src/lib/bq/aos.ts
+++ b/src/lib/bq/aos.ts
@@ -402,3 +402,35 @@ export async function getPageData(
     upcoming: results?.[0]?.upcoming || null,
   };
 }
+
+export async function searchAOsByName(
+  q: string,
+  userIdentifier?: string,
+): Promise<AOInfo[]> {
+  const term = (q || "").trim();
+  if (term.length < 2) return [];
+
+  const escapedTerm = term.replace(/'/g, "''").toLowerCase();
+
+  const query = `-- AO SEARCH
+    SELECT
+      ao_id,
+      ao_name,
+      region_id,
+      region_name,
+      logo_url,
+      is_active
+    FROM pv_aos
+    WHERE ao_name IS NOT NULL
+      AND LOWER(ao_name) LIKE '%${escapedTerm}%'
+    ORDER BY ao_name
+    LIMIT 50
+  `;
+
+  const results = await queryBigQuery<AOInfo>(
+    query,
+    userIdentifier,
+    `search AOs by name: ${q}`,
+  );
+  return results ?? [];
+}

--- a/src/lib/bq/aos.ts
+++ b/src/lib/bq/aos.ts
@@ -423,6 +423,7 @@ export async function searchAOsByName(
     FROM pv_aos
     WHERE ao_name IS NOT NULL
       AND LOWER(ao_name) LIKE '%${escapedTerm}%'
+      AND is_active = TRUE
     ORDER BY ao_name
     LIMIT 50
   `;

--- a/src/lib/bq/pax.ts
+++ b/src/lib/bq/pax.ts
@@ -268,6 +268,7 @@ export async function getEvents(
 export async function searchUsersByName(
   q: string,
   userIdentifier?: string,
+  regionId?: number,
 ): Promise<PAXInfo[]> {
   // Normalize and guard against overly-broad queries.
   const term = (q || "").trim();
@@ -275,6 +276,12 @@ export async function searchUsersByName(
 
   // Escape single quotes to prevent SQL injection via LIKE.
   const escapedTerm = term.replace(/'/g, "''").toLowerCase();
+
+  // Optional region filter: only include PAX whose home region matches.
+  const regionFilter =
+    Number.isFinite(regionId) && regionId !== undefined
+      ? `AND home_region_id = ${Number(regionId)}`
+      : "";
 
   // Simple prefix/contains search; ranking is handled client-side if needed.
   const query = `-- PAX SEARCH
@@ -288,6 +295,7 @@ export async function searchUsersByName(
     FROM pv_pax
     WHERE f3_name IS NOT NULL
       AND LOWER(f3_name) LIKE '%${escapedTerm}%'
+      ${regionFilter}
     ORDER BY f3_name
     LIMIT 50
   `;

--- a/src/lib/bq/pax.ts
+++ b/src/lib/bq/pax.ts
@@ -265,6 +265,26 @@ export async function getEvents(
   return results || null;
 }
 
+export async function getPaxIdByEmail(
+  email: string,
+  userIdentifier?: string,
+): Promise<number | null> {
+  const escaped = email.trim().toLowerCase().replace(/'/g, "''");
+  const query = `-- PAX ID BY EMAIL
+    SELECT id AS user_id
+    FROM \`f3data.public.users\`
+    WHERE email IS NOT NULL
+      AND LOWER(email) = '${escaped}'
+    LIMIT 1
+  `;
+  const results = await queryBigQuery<{ user_id: number }>(
+    query,
+    userIdentifier,
+    "lookup pax id by email",
+  );
+  return results?.[0]?.user_id ?? null;
+}
+
 export async function searchUsersByName(
   q: string,
   userIdentifier?: string,

--- a/src/lib/bq/regions.ts
+++ b/src/lib/bq/regions.ts
@@ -318,6 +318,7 @@ export async function searchRegionsByName(
     FROM pv_regions
     WHERE region_name IS NOT NULL
       AND LOWER(region_name) LIKE '%${escapedTerm}%'
+      AND is_active = TRUE
     ORDER BY region_name
     LIMIT 50
   `;


### PR DESCRIPTION
### 👋 TL;DR

After signing in, users are now automatically redirected to their own PAX page (`/stats/pax/[id]`) instead of the nation stats dashboard.

### 🔎 Details

Previously, the OAuth callback always redirected to `/stats/nation` as the default landing page after login. This change looks up the authenticated user's PAX `user_id` from `f3data.public.users` (joining on email) and redirects them to `/stats/pax/[id]` instead.

**What changed:**
- `src/lib/bq/pax.ts` — new `getPaxIdByEmail()` function queries `f3data.public.users` for the `id` column matching the user's email
- `src/app/api/auth/callback/route.ts` — after the allowlist check, if `returnTo` is the default `/stats/nation`, performs the PAX id lookup and overrides the redirect destination

**Fallback behavior:**
- If the PAX id lookup fails (BQ error) → falls back to `/stats/nation`, error is logged
- If the user's email has no matching PAX record → falls back to `/stats/nation`
- If `returnTo` was explicitly set (e.g. user was redirected to login from a protected page) → original `returnTo` is respected, no lookup performed

### ✅ How to Test

1. **Normal login** — Sign out, navigate to the home page, sign in with no specific destination → should land on `/stats/pax/[your-id]`
2. **Explicit returnTo respected** — Navigate to a protected page while signed out (e.g. `/stats/region/123`) → after login should return to that page, not the PAX page
3. **Fallback** — If testable, use an email that exists in the allowlist but has no PAX record → should land on `/stats/nation`

### 🥜 GIF

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
