### PR TITLE
added upcoming achievements to region

### DIFF
--- a/src/app/stats/region/[regionId]/loader.ts
+++ b/src/app/stats/region/[regionId]/loader.ts
@@ -16,6 +16,7 @@ import {
   Leaders,
   RegionKotterList,
   ChartData,
+  RegionAchievementPax,
 } from "@/lib/types";
 import { getPageData } from "@/lib/bq/regions";
 
@@ -72,6 +73,7 @@ export async function loadRegionData(
       upcoming: (mergedPlain.upcoming ?? []) as EventUpcoming[],
       kotter: (mergedPlain.kotter ?? []) as RegionKotterList[],
       charts: (mergedPlain.charts ?? []) as ChartData[],
+      achievements: (mergedPlain.achievements ?? []) as RegionAchievementPax[],
     };
 
     mergedSafe.events = (mergedSafe.events ?? []).map((e: EventData) => ({

--- a/src/app/stats/region/[regionId]/page.tsx
+++ b/src/app/stats/region/[regionId]/page.tsx
@@ -185,6 +185,7 @@ export default async function RegionDetailPage({
           region_upcoming={regionData.upcoming || []}
           region_events={regionData.events || []}
           region_charts={regionData.charts || []}
+          region_achievements={regionData.achievements || []}
           searchParams={{
             categoryIds,
             categoryMode,

--- a/src/components/region/AchievementsCard.tsx
+++ b/src/components/region/AchievementsCard.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+/**
+ * AchievementsCard
+ *
+ * Displays upcoming PAX milestones for regional leadership: approaching
+ * post/Q counts and FNG anniversaries within the next 14 days.
+ *
+ * - Scope toggle (Region / Nation) adjusts which post and Q counts are
+ *   used for milestone proximity. Anniversaries are scope-independent.
+ * - Type filter tabs (All / Posts / Qs / Anniversaries) narrow the list.
+ */
+
+import { useMemo, useState } from "react";
+import { Avatar } from "@heroui/avatar";
+import { Card, CardBody, CardHeader } from "@heroui/card";
+import { Chip } from "@heroui/chip";
+import { Divider } from "@heroui/divider";
+import { ScrollShadow } from "@heroui/scroll-shadow";
+import { Link } from "@heroui/link";
+import { Tabs, Tab } from "@heroui/tabs";
+import {
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem,
+} from "@heroui/dropdown";
+import { Button } from "@heroui/button";
+import { RegionAchievementPax } from "@/lib/types";
+import { formatDate } from "@/lib/utils";
+
+type AchievementsCardProps = {
+  achievements: RegionAchievementPax[];
+  filters?: string;
+};
+
+type AchievementScope = "region" | "nation";
+type AchievementType = "all" | "posts" | "qs" | "anniversaries";
+
+/** A single computed achievement row shown in the card. */
+interface AchievementRow {
+  user_id: number;
+  f3_name: string;
+  avatar_url?: string;
+  type: "posts" | "qs" | "anniversary";
+  milestone: number;
+  current: number;
+  remaining: number | null; // null for anniversary rows
+  anniversary_date: string | null;
+  days_until: number | null;
+  /** Lower = more urgent; used for sorting */
+  urgency: number;
+}
+
+const POST_THRESHOLD = 5;
+const Q_THRESHOLD = 3;
+const ANNIVERSARY_DAYS = 14;
+
+/** Derive achievement rows from raw PAX data for the given scope. */
+function computeAchievements(
+  achievements: RegionAchievementPax[],
+  scope: AchievementScope,
+): AchievementRow[] {
+  const rows: AchievementRow[] = [];
+
+  for (const pax of achievements) {
+    const posts = scope === "nation" ? pax.all_posts : pax.region_posts;
+    const qs = scope === "nation" ? pax.all_qs : pax.region_qs;
+    const nextPostMilestone =
+      scope === "nation"
+        ? pax.next_nation_post_milestone
+        : pax.next_region_post_milestone;
+    const nextQMilestone =
+      scope === "nation"
+        ? pax.next_nation_q_milestone
+        : pax.next_region_q_milestone;
+
+    // Post milestone
+    if (
+      nextPostMilestone !== null &&
+      nextPostMilestone - posts <= POST_THRESHOLD
+    ) {
+      const remaining = nextPostMilestone - posts;
+      rows.push({
+        user_id: pax.user_id,
+        f3_name: pax.f3_name,
+        avatar_url: pax.avatar_url,
+        type: "posts",
+        milestone: nextPostMilestone,
+        current: posts,
+        remaining,
+        anniversary_date: null,
+        days_until: null,
+        urgency: remaining,
+      });
+    }
+
+    // Q milestone
+    if (nextQMilestone !== null && nextQMilestone - qs <= Q_THRESHOLD) {
+      const remaining = nextQMilestone - qs;
+      rows.push({
+        user_id: pax.user_id,
+        f3_name: pax.f3_name,
+        avatar_url: pax.avatar_url,
+        type: "qs",
+        milestone: nextQMilestone,
+        current: qs,
+        remaining,
+        anniversary_date: null,
+        days_until: null,
+        urgency: remaining,
+      });
+    }
+
+    // Anniversary (scope-independent; shown exactly once per PAX regardless of scope)
+    if (
+      pax.next_anniversary_date &&
+      pax.days_until_anniversary !== null &&
+      pax.days_until_anniversary >= 0 &&
+      pax.days_until_anniversary <= ANNIVERSARY_DAYS
+    ) {
+      rows.push({
+        user_id: pax.user_id,
+        f3_name: pax.f3_name,
+        avatar_url: pax.avatar_url,
+        type: "anniversary",
+        milestone: 0, // milestone_value not needed for display; year computed below
+        current: 0,
+        remaining: null,
+        anniversary_date: pax.next_anniversary_date,
+        days_until: pax.days_until_anniversary,
+        urgency: pax.days_until_anniversary,
+      });
+    }
+  }
+
+  return rows;
+}
+
+/** Chip color and label by achievement type. */
+function typeChip(type: AchievementRow["type"]) {
+  if (type === "posts")
+    return (
+      <Chip size="sm" color="primary" variant="flat">
+        Posts
+      </Chip>
+    );
+  if (type === "qs")
+    return (
+      <Chip size="sm" color="secondary" variant="flat">
+        Qs
+      </Chip>
+    );
+  return (
+    <Chip size="sm" color="warning" variant="flat">
+      Anniversary
+    </Chip>
+  );
+}
+
+/** Human-readable description of a row's milestone. */
+function milestoneDescription(row: AchievementRow): string {
+  if (row.type === "anniversary" && row.anniversary_date) {
+    const dateStr = formatDate(row.anniversary_date, "M D Y");
+    const daysStr =
+      row.days_until === 0
+        ? "today!"
+        : row.days_until === 1
+          ? "tomorrow"
+          : `in ${row.days_until} days`;
+
+    const year = row.current > 0 ? row.current : undefined;
+    const yearLabel =
+      year !== undefined ? `${year}-year anniversary` : `FNG anniversary`;
+
+    return `${yearLabel} — ${dateStr} (${daysStr})`;
+  }
+
+  if (row.remaining === 1) {
+    return `1 ${row.type === "posts" ? "post" : "Q"} away from ${row.milestone}`;
+  }
+  return `${row.remaining} ${row.type === "posts" ? "posts" : "Qs"} away from ${row.milestone}`;
+}
+
+export function AchievementsCard({
+  achievements,
+  filters,
+}: AchievementsCardProps) {
+  const [scope, setScope] = useState<AchievementScope>("region");
+  const [typeFilter, setTypeFilter] = useState<AchievementType>("all");
+
+  const allRows = useMemo(
+    () => computeAchievements(achievements, scope),
+    [achievements, scope],
+  );
+
+  const visibleRows = useMemo(() => {
+    const filtered =
+      typeFilter === "all"
+        ? allRows
+        : typeFilter === "anniversaries"
+          ? allRows.filter((r) => r.type === "anniversary")
+          : allRows.filter((r) => r.type === typeFilter);
+
+    // Anniversaries first (by days_until ASC), then count milestones (by remaining ASC), then name
+    return [...filtered].sort((a, b) => {
+      const aIsAnniv = a.type === "anniversary" ? 0 : 1;
+      const bIsAnniv = b.type === "anniversary" ? 0 : 1;
+      if (aIsAnniv !== bIsAnniv) return aIsAnniv - bIsAnniv;
+      if (a.urgency !== b.urgency) return a.urgency - b.urgency;
+      return a.f3_name.localeCompare(b.f3_name);
+    });
+  }, [allRows, typeFilter]);
+
+  // Compute year for anniversary rows: use fng_date from achievements
+  // We annotate anniversary rows with the year at display time.
+  const anniversaryYears = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const pax of achievements) {
+      if (pax.fng_date && pax.next_anniversary_date) {
+        const fng = new Date(pax.fng_date);
+        const anniv = new Date(pax.next_anniversary_date);
+        const year = anniv.getUTCFullYear() - fng.getUTCFullYear();
+        map.set(pax.user_id, year);
+      }
+    }
+    return map;
+  }, [achievements]);
+
+  return (
+    <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
+      <CardHeader className="flex justify-between items-center px-6">
+        <div className="flex items-center justify-between w-full gap-3">
+          <div className="font-semibold text-xl">Achievements</div>
+          <div className="flex items-center gap-2 flex-wrap justify-end">
+            <Tabs
+              aria-label="Select achievement scope"
+              selectedKey={scope}
+              onSelectionChange={(key) => setScope(key as AchievementScope)}
+              size="sm"
+              radius="sm"
+              variant="bordered"
+              color="secondary"
+            >
+              <Tab key="region" title="Region" />
+              <Tab key="nation" title="Nation" />
+            </Tabs>
+            <Dropdown>
+              <DropdownTrigger>
+                <Button size="md" variant="bordered" color="default">
+                  {
+                    {
+                      all: "All",
+                      posts: "Posts",
+                      qs: "Qs",
+                      anniversaries: "Anniversaries",
+                    }[typeFilter]
+                  }
+                </Button>
+              </DropdownTrigger>
+              <DropdownMenu
+                aria-label="Filter achievement type"
+                selectionMode="single"
+                selectedKeys={new Set([typeFilter])}
+                onSelectionChange={(keys) => {
+                  const first = Array.from(keys as Set<string>)[0];
+                  setTypeFilter((first ?? "all") as AchievementType);
+                }}
+              >
+                <DropdownItem key="all">All</DropdownItem>
+                <DropdownItem key="posts">Posts</DropdownItem>
+                <DropdownItem key="qs">Qs</DropdownItem>
+                <DropdownItem key="anniversaries">Anniversaries</DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+          </div>
+        </div>
+      </CardHeader>
+      <Divider />
+      <CardBody className="px-6">
+        <ScrollShadow className="h-[1105px]">
+          <div className="space-y-1 text-sm">
+            {visibleRows.length === 0 ? (
+              <div className="italic text-default-500 text-sm py-2">
+                No upcoming achievements for this view.
+              </div>
+            ) : (
+              visibleRows.map((row, idx) => {
+                // For anniversary rows, replace the computed `current` with the actual year
+                const displayRow =
+                  row.type === "anniversary"
+                    ? {
+                        ...row,
+                        current:
+                          anniversaryYears.get(row.user_id) ?? row.current,
+                      }
+                    : row;
+
+                return (
+                  <div
+                    key={`${row.user_id}-${row.type}-${idx}`}
+                    className="flex justify-between items-center py-1 pb-2 border-b light:border-black/10 dark:border-white/10"
+                  >
+                    <div className="flex items-center gap-2 text-sm min-w-0">
+                      <Avatar
+                        alt={row.f3_name ?? row.user_id.toString()}
+                        className="flex-shrink-0"
+                        size="sm"
+                        src={row.avatar_url}
+                      />
+                      <div className="flex flex-col gap-0.5 min-w-0">
+                        <Link
+                          className="text-sm"
+                          color="primary"
+                          href={`/stats/pax/${row.user_id}${filters ? `?${filters}` : ""}`}
+                        >
+                          {row.f3_name ?? row.user_id.toString()}
+                        </Link>
+                        <span className="text-xs text-default-500 truncate">
+                          {milestoneDescription(displayRow)}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="flex-shrink-0 ml-3">
+                      {typeChip(row.type)}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </ScrollShadow>
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/components/region/PageWrapper.tsx
+++ b/src/components/region/PageWrapper.tsx
@@ -18,6 +18,7 @@ import {
   EventUpcoming,
   RegionInfo,
   ChartData,
+  RegionAchievementPax,
 } from "@/lib/types";
 import { SummaryCard } from "./SummaryCard";
 import { LeadersCard } from "../leaders";
@@ -27,6 +28,7 @@ import { EventsCard } from "../events";
 import { Filter } from "../pageFilter";
 import { useMemo } from "react";
 import { ChartCard } from "./ChartsCard";
+import { AchievementsCard } from "./AchievementsCard";
 
 type RegionalPageWrapperProps = {
   region_id: number;
@@ -37,6 +39,7 @@ type RegionalPageWrapperProps = {
   region_upcoming: EventUpcoming[] | null;
   region_events: EventData[];
   region_charts: ChartData[];
+  region_achievements: RegionAchievementPax[];
   searchParams: {
     categoryIds?: string | string[];
     categoryMode?: string;
@@ -100,6 +103,7 @@ export function RegionalPageWrapper({
   region_upcoming,
   region_events,
   region_charts,
+  region_achievements,
   searchParams,
 }: RegionalPageWrapperProps) {
   // Memoized query-string passed to events + filter components.
@@ -139,16 +143,23 @@ export function RegionalPageWrapper({
       <div className="grid grid-cols-1 gap-6 w-full max-w-6xl hidden">
         <ChartCard charts={region_charts || []} />
       </div>
-      {/* Kotters + upcoming events */}
+      {/* Upcoming achievements */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 w-full max-w-6xl">
-        <KotterCard
-          kotters={region_kotter || []}
+        <AchievementsCard
+          achievements={region_achievements || []}
           filters={eventsFiltersQuery}
         />
-        <UpcomingEventsCard
-          events={region_upcoming || []}
-          filters={eventsFiltersQuery}
-        />
+        {/* Kotters + upcoming events */}
+        <div className="grid grid-cols-1 gap-6 w-full max-w-6xl">
+          <KotterCard
+            kotters={region_kotter || []}
+            filters={eventsFiltersQuery}
+          />
+          <UpcomingEventsCard
+            events={region_upcoming || []}
+            filters={eventsFiltersQuery}
+          />
+        </div>
       </div>
       {/* Event list */}
       <div className="grid grid-cols-1 gap-6 w-full max-w-6xl">

--- a/src/lib/bq/regions.ts
+++ b/src/lib/bq/regions.ts
@@ -7,6 +7,7 @@ import {
   EventUpcoming,
   RegionKotterList,
   ChartData,
+  RegionAchievementPax,
 } from "@/lib/types";
 
 /**
@@ -352,6 +353,7 @@ export async function getPageData(
         unique_q_count: number;
       }[]
     | null;
+  achievements: RegionAchievementPax[] | null;
 }> {
   // Build WHERE clause from common filters (region-scoped).
   const whereSql = buildEventsWhereSql(regionId, opts);
@@ -453,6 +455,85 @@ export async function getPageData(
           ON li.user_id = a.user_id
         WHERE a.user_id IS NOT NULL${eventsFilterAndSql}
         GROUP BY a.user_id
+      ),
+
+      -- ── Achievements ────────────────────────────────────────────────────────
+      -- Milestone thresholds shared across posts and Qs
+      achievement_thresholds AS (
+        SELECT t FROM UNNEST([25, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]) AS t
+      ),
+
+      -- All home-region PAX from pv_pax (source of truth for membership + FNG override)
+      achievement_pax_base AS (
+        SELECT user_id, f3_name, avatar_url, start_date_override
+        FROM pv_pax
+        WHERE home_region_id = ${regionId}
+      ),
+
+      -- Single pass over pv_events for all four count dimensions + first_event_date
+      -- (all-time, no date filter so milestones reflect career totals)
+      achievement_event_counts AS (
+        SELECT
+          a.user_id,
+          COUNT(DISTINCT IF(e.region_org_id = ${regionId}, e.event_id, NULL)) AS region_posts,
+          COUNT(DISTINCT IF(e.region_org_id = ${regionId} AND a.q_ind = 1, e.event_id, NULL)) AS region_qs,
+          COUNT(DISTINCT e.event_id) AS all_posts,
+          COUNT(DISTINCT IF(a.q_ind = 1, e.event_id, NULL)) AS all_qs,
+          MIN(e.event_date) AS first_event_date
+        FROM pv_events e
+        JOIN UNNEST(e.attendance) a ON TRUE
+        JOIN achievement_pax_base pb ON pb.user_id = a.user_id
+        GROUP BY a.user_id
+      ),
+
+      -- Combine pv_pax fields with computed counts; resolve fng_date using override.
+      -- Mirrors pax.ts: IFNULL(CAST(start_date_override AS STRING), CAST(first_event_date AS STRING))
+      -- fng_date is kept as STRING so DATE(fng_date) can be used for anniversary math.
+      achievement_pax AS (
+        SELECT
+          pb.user_id,
+          pb.f3_name,
+          pb.avatar_url,
+          COALESCE(ec.region_posts, 0) AS region_posts,
+          COALESCE(ec.region_qs, 0) AS region_qs,
+          COALESCE(ec.all_posts, 0) AS all_posts,
+          COALESCE(ec.all_qs, 0) AS all_qs,
+          IFNULL(
+            CAST(pb.start_date_override AS STRING),
+            CAST(ec.first_event_date AS STRING)
+          ) AS fng_date
+        FROM achievement_pax_base pb
+        LEFT JOIN achievement_event_counts ec ON ec.user_id = pb.user_id
+      ),
+
+      -- Cross with thresholds to find next milestone per count dimension.
+      -- Also computes next_anniversary_date correctly:
+      --   use this year's month/day; if already past, use next year.
+      -- This avoids DATE_DIFF(YEAR) which counts calendar boundaries, not completed anniversaries.
+      achievement_pax_milestones AS (
+        SELECT
+          p.user_id, p.f3_name, p.avatar_url,
+          p.region_posts, p.region_qs, p.all_posts, p.all_qs, p.fng_date,
+          MIN(CASE WHEN t.t > p.region_posts THEN t.t END) AS next_region_post_milestone,
+          MIN(CASE WHEN t.t > p.all_posts    THEN t.t END) AS next_nation_post_milestone,
+          MIN(CASE WHEN t.t > p.region_qs   THEN t.t END) AS next_region_q_milestone,
+          MIN(CASE WHEN t.t > p.all_qs      THEN t.t END) AS next_nation_q_milestone,
+          -- Use DATE_ADD (not EXTRACT) so leap-year FNG dates (Feb 29) roll safely to Feb 28.
+          -- year_diff = calendar years between FNG year and today's year.
+          -- "this year's anniversary" = DATE_ADD(fng_date, INTERVAL year_diff YEAR).
+          -- If that date has already passed, add one more year.
+          IF(p.fng_date IS NOT NULL,
+            CASE
+              WHEN DATE_ADD(DATE(p.fng_date), INTERVAL (EXTRACT(YEAR FROM CURRENT_DATE()) - EXTRACT(YEAR FROM DATE(p.fng_date))) YEAR) >= CURRENT_DATE()
+              THEN DATE_ADD(DATE(p.fng_date), INTERVAL (EXTRACT(YEAR FROM CURRENT_DATE()) - EXTRACT(YEAR FROM DATE(p.fng_date))) YEAR)
+              ELSE DATE_ADD(DATE(p.fng_date), INTERVAL (EXTRACT(YEAR FROM CURRENT_DATE()) - EXTRACT(YEAR FROM DATE(p.fng_date)) + 1) YEAR)
+            END,
+            NULL
+          ) AS next_anniversary_date
+        FROM achievement_pax p
+        CROSS JOIN achievement_thresholds t
+        GROUP BY p.user_id, p.f3_name, p.avatar_url,
+                 p.region_posts, p.region_qs, p.all_posts, p.all_qs, p.fng_date
       )
     SELECT
       -- Region info as a STRUCT
@@ -587,6 +668,35 @@ export async function getPageData(
         WHERE home_region_id = ${regionId}
       ) AS kotter,
 
+      -- Achievements: PAX approaching post/Q milestones or with upcoming anniversaries
+      (
+        SELECT ARRAY_AGG(
+          STRUCT(
+            user_id, f3_name, avatar_url,
+            region_posts, region_qs, all_posts, all_qs,
+            next_region_post_milestone,
+            next_nation_post_milestone,
+            next_region_q_milestone,
+            next_nation_q_milestone,
+            fng_date,
+            CAST(next_anniversary_date AS STRING) AS next_anniversary_date,
+            IF(next_anniversary_date IS NOT NULL,
+              DATE_DIFF(next_anniversary_date, CURRENT_DATE(), DAY),
+              NULL
+            ) AS days_until_anniversary
+          )
+          ORDER BY f3_name ASC
+        )
+        FROM achievement_pax_milestones
+        WHERE
+          ((next_region_post_milestone IS NOT NULL AND next_region_post_milestone - region_posts <= 5)
+          OR (next_nation_post_milestone IS NOT NULL AND next_nation_post_milestone - all_posts <= 5)
+          OR (next_region_q_milestone IS NOT NULL AND next_region_q_milestone - region_qs <= 3)
+          OR (next_nation_q_milestone IS NOT NULL AND next_nation_q_milestone - all_qs <= 3)
+          OR (next_anniversary_date IS NOT NULL AND DATE_DIFF(next_anniversary_date, CURRENT_DATE(), DAY) BETWEEN 0 AND 14))
+          AND (region_posts > 10) -- Filter out very new PAX with no significant activity (adjust threshold as needed)
+      ) AS achievements,
+
       -- Charting: ${chartGranularity} aggregation with gap-filling
       (
         WITH
@@ -653,6 +763,7 @@ export async function getPageData(
     upcoming: EventUpcoming[];
     kotter: RegionKotterList[];
     charts: ChartData[];
+    achievements: RegionAchievementPax[];
   }>(query, userIdentifier, `fetch region data for region ${regionId}`);
 
   return {
@@ -663,5 +774,6 @@ export async function getPageData(
     upcoming: results?.[0]?.upcoming || null,
     kotter: results?.[0]?.kotter || null,
     charts: results?.[0]?.charts || null,
+    achievements: results?.[0]?.achievements || null,
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -113,6 +113,7 @@ export interface RegionData {
   upcoming: EventUpcoming[] | null; // List of upcoming events in the region
   kotter: RegionKotterList[] | null; // List of Kotter events in the region
   charts: ChartData[] | null; // List of chart data points for the region
+  achievements: RegionAchievementPax[] | null; // PAX approaching milestones or with upcoming anniversaries
 }
 
 /* USED ONLY FOR REGION INFO */
@@ -136,6 +137,24 @@ export interface RegionSummary {
   unique_qs: number; // Number of unique Qs (leaders) who have led events in the region
   fng_count: number; // Total number of first-time participants (FNGs) in the region
   pax_count_average: number; // Average number of participants (pax) per event in the region
+}
+
+/* USED FOR REGION UPCOMING ACHIEVEMENTS */
+export interface RegionAchievementPax {
+  user_id: number; // Unique identifier for the user
+  f3_name: string; // F3 name (nickname) of the user
+  avatar_url?: string; // Optional URL to the user's avatar image
+  region_posts: number; // Total posts (events attended) in this region
+  region_qs: number; // Total Qs led in this region
+  all_posts: number; // Total posts across all regions
+  all_qs: number; // Total Qs across all regions
+  next_region_post_milestone: number | null; // Next post milestone in this region
+  next_nation_post_milestone: number | null; // Next post milestone across all regions
+  next_region_q_milestone: number | null; // Next Q milestone in this region
+  next_nation_q_milestone: number | null; // Next Q milestone across all regions
+  fng_date: string | null; // FNG/first-event date (ISO string)
+  next_anniversary_date: string | null; // Date of next FNG anniversary (ISO string)
+  days_until_anniversary: number | null; // Days until the next FNG anniversary
 }
 
 /* USED ONLY FOR REGION KOTTER LISTING */


### PR DESCRIPTION
### 👋 TL;DR

Adds an Upcoming Achievements card to the region page, surfacing PAX who are approaching post/Q milestones or have an FNG anniversary within the next 14 days.

### 🔎 Details

New `AchievementsCard` component powered by a new BigQuery CTE in `getPageData`. The card shows region-level PAX approaching post milestones (within 5) or Q milestones (within 3), as well as FNG anniversaries in the next 14 days. Users can toggle between Region and Nation scope and filter by achievement type (All / Posts / Qs / Anniversaries) via a dropdown. Rows are sorted by urgency — anniversaries first by days remaining, then milestones by count remaining.

Data plumbing runs through a new `RegionAchievementPax` type in `types.ts`, a new achievements CTE in `regions.ts`, and updated props in `loader.ts`, `page.tsx`, and `PageWrapper.tsx`.

### ✅ How to Test

- [ ] Region page loads without error when achievements data is present
- [ ] Region page loads without error when `achievements` is `null` or empty
- [ ] Region/Nation scope toggle correctly switches post and Q counts
- [ ] All/Posts/Qs/Anniversaries dropdown filters the list correctly
- [ ] Anniversary rows show the correct year label and days-until string
- [ ] PAX with no approaching milestone and no upcoming anniversary do not appear
- [ ] Layout renders correctly on mobile (single column) and desktop (2-column, Kotter + Upcoming Events stacked right)

### 🥜 GIF

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)