### PR TITLE
Area42

### DIFF
--- a/src/app/api/ao/list/route.ts
+++ b/src/app/api/ao/list/route.ts
@@ -19,6 +19,7 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const rawQuery = searchParams.get("q") || "";
   const q = rawQuery.trim();
+  const includeInactive = searchParams.get("includeInactive") === "true";
 
   // Guardrail: do not allow overly-broad or empty searches.
   if (q.length < 2) {
@@ -26,7 +27,7 @@ export async function GET(request: Request) {
   }
 
   try {
-    const aos = await searchAOsByName(q, user.email);
+    const aos = await searchAOsByName(q, user.email, includeInactive);
     return NextResponse.json(aos, { status: 200 });
   } catch (err) {
     console.error("AO search failed:", err);

--- a/src/app/api/region/list/route.ts
+++ b/src/app/api/region/list/route.ts
@@ -19,6 +19,7 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const rawQuery = searchParams.get("q") || "";
   const q = rawQuery.trim();
+  const includeInactive = searchParams.get("includeInactive") === "true";
 
   // Guardrail: do not allow overly-broad or empty searches.
   if (q.length < 2) {
@@ -26,7 +27,7 @@ export async function GET(request: Request) {
   }
 
   try {
-    const regions = await searchRegionsByName(q, user.email);
+    const regions = await searchRegionsByName(q, user.email, includeInactive);
     return NextResponse.json(regions, { status: 200 });
   } catch (err) {
     console.error("Region search failed:", err);

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { searchAll } from "@/lib/bq/search";
+import { getSessionUser } from "@/lib/auth/server";
+
+export async function GET(request: Request) {
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const rawQuery = searchParams.get("q") || "";
+  const q = rawQuery.trim();
+  const includeInactive = searchParams.get("includeInactive") === "true";
+
+  if (q.length < 2) {
+    return NextResponse.json({ regions: [], aos: [], pax: [] }, { status: 200 });
+  }
+
+  try {
+    const results = await searchAll(q, user.email, includeInactive);
+    return NextResponse.json(results, { status: 200 });
+  } catch (err) {
+    console.error("Search failed:", err);
+    return NextResponse.json(
+      { error: "Search failed. Please try again." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -14,7 +14,10 @@ export async function GET(request: Request) {
   const includeInactive = searchParams.get("includeInactive") === "true";
 
   if (q.length < 2) {
-    return NextResponse.json({ regions: [], aos: [], pax: [] }, { status: 200 });
+    return NextResponse.json(
+      { regions: [], aos: [], pax: [] },
+      { status: 200 },
+    );
   }
 
   try {

--- a/src/app/stats/region/[regionId]/loader.ts
+++ b/src/app/stats/region/[regionId]/loader.ts
@@ -16,6 +16,7 @@ import {
   Leaders,
   RegionKotterList,
   ChartData,
+  RegionAchievementPax,
 } from "@/lib/types";
 import { getPageData } from "@/lib/bq/regions";
 
@@ -72,6 +73,7 @@ export async function loadRegionData(
       upcoming: (mergedPlain.upcoming ?? []) as EventUpcoming[],
       kotter: (mergedPlain.kotter ?? []) as RegionKotterList[],
       charts: (mergedPlain.charts ?? []) as ChartData[],
+      achievements: (mergedPlain.achievements ?? []) as RegionAchievementPax[],
     };
 
     mergedSafe.events = (mergedSafe.events ?? []).map((e: EventData) => ({

--- a/src/app/stats/region/[regionId]/page.tsx
+++ b/src/app/stats/region/[regionId]/page.tsx
@@ -185,6 +185,7 @@ export default async function RegionDetailPage({
           region_upcoming={regionData.upcoming || []}
           region_events={regionData.events || []}
           region_charts={regionData.charts || []}
+          region_achievements={regionData.achievements || []}
           searchParams={{
             categoryIds,
             categoryMode,

--- a/src/components/region/AchievementsCard.tsx
+++ b/src/components/region/AchievementsCard.tsx
@@ -50,6 +50,10 @@ interface AchievementRow {
   days_until: number | null;
   /** Lower = more urgent; used for sorting */
   urgency: number;
+  /** Scope-based post count — used for Q and anniversary rows */
+  total_posts?: number;
+  /** FNG date string — used for post rows to compute longevity */
+  fng_date?: string;
 }
 
 const POST_THRESHOLD = 5;
@@ -75,49 +79,63 @@ function computeAchievements(
         ? pax.next_nation_q_milestone
         : pax.next_region_q_milestone;
 
+    const recentlyActive =
+      pax.last_region_event_date !== null &&
+      (new Date().getTime() - new Date(pax.last_region_event_date).getTime()) /
+        (1000 * 60 * 60 * 24) <=
+        30;
+
     // Post milestone
     if (
       nextPostMilestone !== null &&
       nextPostMilestone - posts <= POST_THRESHOLD
     ) {
       const remaining = nextPostMilestone - posts;
-      rows.push({
-        user_id: pax.user_id,
-        f3_name: pax.f3_name,
-        avatar_url: pax.avatar_url,
-        type: "posts",
-        milestone: nextPostMilestone,
-        current: posts,
-        remaining,
-        anniversary_date: null,
-        days_until: null,
-        urgency: remaining,
-      });
+      if (remaining <= 1 || recentlyActive) {
+        rows.push({
+          user_id: pax.user_id,
+          f3_name: pax.f3_name,
+          avatar_url: pax.avatar_url,
+          type: "posts",
+          milestone: nextPostMilestone,
+          current: posts,
+          remaining,
+          anniversary_date: null,
+          days_until: null,
+          urgency: remaining,
+          fng_date: pax.fng_date ?? undefined,
+        });
+      }
     }
 
     // Q milestone
     if (nextQMilestone !== null && nextQMilestone - qs <= Q_THRESHOLD) {
       const remaining = nextQMilestone - qs;
-      rows.push({
-        user_id: pax.user_id,
-        f3_name: pax.f3_name,
-        avatar_url: pax.avatar_url,
-        type: "qs",
-        milestone: nextQMilestone,
-        current: qs,
-        remaining,
-        anniversary_date: null,
-        days_until: null,
-        urgency: remaining,
-      });
+      if (remaining <= 1 || recentlyActive) {
+        rows.push({
+          user_id: pax.user_id,
+          f3_name: pax.f3_name,
+          avatar_url: pax.avatar_url,
+          type: "qs",
+          milestone: nextQMilestone,
+          current: qs,
+          remaining,
+          anniversary_date: null,
+          days_until: null,
+          urgency: remaining,
+          total_posts: posts,
+        });
+      }
     }
 
     // Anniversary (scope-independent; shown exactly once per PAX regardless of scope)
+    // Require at least 25 region posts so very new PAX don't trigger anniversary notifications.
     if (
       pax.next_anniversary_date &&
       pax.days_until_anniversary !== null &&
       pax.days_until_anniversary >= 0 &&
-      pax.days_until_anniversary <= ANNIVERSARY_DAYS
+      pax.days_until_anniversary <= ANNIVERSARY_DAYS &&
+      pax.region_posts >= 25
     ) {
       rows.push({
         user_id: pax.user_id,
@@ -130,11 +148,39 @@ function computeAchievements(
         anniversary_date: pax.next_anniversary_date,
         days_until: pax.days_until_anniversary,
         urgency: pax.days_until_anniversary,
+        total_posts: posts,
       });
     }
   }
 
   return rows;
+}
+
+/** Format PAX longevity from fng_date to today as "X weeks", "X months", or "X years, Y months". */
+function formatLongevity(fngDate: string): string {
+  const fng = new Date(fngDate);
+  const now = new Date();
+  const totalDays = Math.floor(
+    (now.getTime() - fng.getTime()) / (1000 * 60 * 60 * 24),
+  );
+  const totalWeeks = Math.floor(totalDays / 7);
+
+  if (totalWeeks < 8) {
+    return `${totalWeeks} week${totalWeeks !== 1 ? "s" : ""}`;
+  }
+
+  const years = Math.floor(totalDays / 365.25);
+  const remainingMonths = Math.round(((totalDays % 365.25) / 365.25) * 12);
+
+  if (years < 1) {
+    const totalMonths = Math.round(totalDays / 30.44);
+    return `${totalMonths} month${totalMonths !== 1 ? "s" : ""}`;
+  }
+
+  if (remainingMonths === 0) {
+    return `${years} year${years !== 1 ? "s" : ""}`;
+  }
+  return `${years} year${years !== 1 ? "s" : ""}, ${remainingMonths} month${remainingMonths !== 1 ? "s" : ""}`;
 }
 
 /** Chip color and label by achievement type. */
@@ -170,16 +216,35 @@ function milestoneDescription(row: AchievementRow): string {
           : `in ${row.days_until} days`;
 
     const year = row.current > 0 ? row.current : undefined;
-    const yearLabel =
-      year !== undefined ? `${year}-year anniversary` : `FNG anniversary`;
+    const yearLabel = year !== undefined ? `${year}-years` : `FNG anniversary`;
 
-    return `${yearLabel} — ${dateStr} (${daysStr})`;
+    const eventsStr =
+      row.total_posts !== undefined ? ` · ${row.total_posts} events` : "";
+
+    return `${yearLabel} — ${dateStr} (${daysStr})${eventsStr}`;
   }
 
-  if (row.remaining === 1) {
-    return `1 ${row.type === "posts" ? "post" : "Q"} away from ${row.milestone}`;
+  if (row.type === "qs") {
+    const base =
+      row.remaining === 1
+        ? `1 Q away from ${row.milestone}`
+        : `${row.remaining} Qs away from ${row.milestone}`;
+    if (row.total_posts !== undefined && row.total_posts > 0) {
+      const qRate = Math.round((row.current / row.total_posts) * 100);
+      return `${base} · ${row.total_posts} posts, ${qRate}% Q rate`;
+    }
+    return base;
   }
-  return `${row.remaining} ${row.type === "posts" ? "posts" : "Qs"} away from ${row.milestone}`;
+
+  // posts
+  const base =
+    row.remaining === 1
+      ? `1 post away from ${row.milestone}`
+      : `${row.remaining} posts away from ${row.milestone}`;
+  if (row.fng_date) {
+    return `${base} · PAX for ${formatLongevity(row.fng_date)}`;
+  }
+  return base;
 }
 
 export function AchievementsCard({

--- a/src/components/region/AchievementsCard.tsx
+++ b/src/components/region/AchievementsCard.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+/**
+ * AchievementsCard
+ *
+ * Displays upcoming PAX milestones for regional leadership: approaching
+ * post/Q counts and FNG anniversaries within the next 14 days.
+ *
+ * - Scope toggle (Region / Nation) adjusts which post and Q counts are
+ *   used for milestone proximity. Anniversaries are scope-independent.
+ * - Type filter tabs (All / Posts / Qs / Anniversaries) narrow the list.
+ */
+
+import { useMemo, useState } from "react";
+import { Avatar } from "@heroui/avatar";
+import { Card, CardBody, CardHeader } from "@heroui/card";
+import { Chip } from "@heroui/chip";
+import { Divider } from "@heroui/divider";
+import { ScrollShadow } from "@heroui/scroll-shadow";
+import { Link } from "@heroui/link";
+import { Tabs, Tab } from "@heroui/tabs";
+import {
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem,
+} from "@heroui/dropdown";
+import { Button } from "@heroui/button";
+import { RegionAchievementPax } from "@/lib/types";
+import { formatDate } from "@/lib/utils";
+
+type AchievementsCardProps = {
+  achievements: RegionAchievementPax[];
+  filters?: string;
+};
+
+type AchievementScope = "region" | "nation";
+type AchievementType = "all" | "posts" | "qs" | "anniversaries";
+
+/** A single computed achievement row shown in the card. */
+interface AchievementRow {
+  user_id: number;
+  f3_name: string;
+  avatar_url?: string;
+  type: "posts" | "qs" | "anniversary";
+  milestone: number;
+  current: number;
+  remaining: number | null; // null for anniversary rows
+  anniversary_date: string | null;
+  days_until: number | null;
+  /** Lower = more urgent; used for sorting */
+  urgency: number;
+}
+
+const POST_THRESHOLD = 5;
+const Q_THRESHOLD = 3;
+const ANNIVERSARY_DAYS = 14;
+
+/** Derive achievement rows from raw PAX data for the given scope. */
+function computeAchievements(
+  achievements: RegionAchievementPax[],
+  scope: AchievementScope,
+): AchievementRow[] {
+  const rows: AchievementRow[] = [];
+
+  for (const pax of achievements) {
+    const posts = scope === "nation" ? pax.all_posts : pax.region_posts;
+    const qs = scope === "nation" ? pax.all_qs : pax.region_qs;
+    const nextPostMilestone =
+      scope === "nation"
+        ? pax.next_nation_post_milestone
+        : pax.next_region_post_milestone;
+    const nextQMilestone =
+      scope === "nation"
+        ? pax.next_nation_q_milestone
+        : pax.next_region_q_milestone;
+
+    // Post milestone
+    if (
+      nextPostMilestone !== null &&
+      nextPostMilestone - posts <= POST_THRESHOLD
+    ) {
+      const remaining = nextPostMilestone - posts;
+      rows.push({
+        user_id: pax.user_id,
+        f3_name: pax.f3_name,
+        avatar_url: pax.avatar_url,
+        type: "posts",
+        milestone: nextPostMilestone,
+        current: posts,
+        remaining,
+        anniversary_date: null,
+        days_until: null,
+        urgency: remaining,
+      });
+    }
+
+    // Q milestone
+    if (nextQMilestone !== null && nextQMilestone - qs <= Q_THRESHOLD) {
+      const remaining = nextQMilestone - qs;
+      rows.push({
+        user_id: pax.user_id,
+        f3_name: pax.f3_name,
+        avatar_url: pax.avatar_url,
+        type: "qs",
+        milestone: nextQMilestone,
+        current: qs,
+        remaining,
+        anniversary_date: null,
+        days_until: null,
+        urgency: remaining,
+      });
+    }
+
+    // Anniversary (scope-independent; shown exactly once per PAX regardless of scope)
+    if (
+      pax.next_anniversary_date &&
+      pax.days_until_anniversary !== null &&
+      pax.days_until_anniversary >= 0 &&
+      pax.days_until_anniversary <= ANNIVERSARY_DAYS
+    ) {
+      rows.push({
+        user_id: pax.user_id,
+        f3_name: pax.f3_name,
+        avatar_url: pax.avatar_url,
+        type: "anniversary",
+        milestone: 0, // milestone_value not needed for display; year computed below
+        current: 0,
+        remaining: null,
+        anniversary_date: pax.next_anniversary_date,
+        days_until: pax.days_until_anniversary,
+        urgency: pax.days_until_anniversary,
+      });
+    }
+  }
+
+  return rows;
+}
+
+/** Chip color and label by achievement type. */
+function typeChip(type: AchievementRow["type"]) {
+  if (type === "posts")
+    return (
+      <Chip size="sm" color="primary" variant="flat">
+        Posts
+      </Chip>
+    );
+  if (type === "qs")
+    return (
+      <Chip size="sm" color="secondary" variant="flat">
+        Qs
+      </Chip>
+    );
+  return (
+    <Chip size="sm" color="warning" variant="flat">
+      Anniversary
+    </Chip>
+  );
+}
+
+/** Human-readable description of a row's milestone. */
+function milestoneDescription(row: AchievementRow): string {
+  if (row.type === "anniversary" && row.anniversary_date) {
+    const dateStr = formatDate(row.anniversary_date, "M D Y");
+    const daysStr =
+      row.days_until === 0
+        ? "today!"
+        : row.days_until === 1
+          ? "tomorrow"
+          : `in ${row.days_until} days`;
+
+    const year = row.current > 0 ? row.current : undefined;
+    const yearLabel =
+      year !== undefined ? `${year}-year anniversary` : `FNG anniversary`;
+
+    return `${yearLabel} — ${dateStr} (${daysStr})`;
+  }
+
+  if (row.remaining === 1) {
+    return `1 ${row.type === "posts" ? "post" : "Q"} away from ${row.milestone}`;
+  }
+  return `${row.remaining} ${row.type === "posts" ? "posts" : "Qs"} away from ${row.milestone}`;
+}
+
+export function AchievementsCard({
+  achievements,
+  filters,
+}: AchievementsCardProps) {
+  const [scope, setScope] = useState<AchievementScope>("region");
+  const [typeFilter, setTypeFilter] = useState<AchievementType>("all");
+
+  const allRows = useMemo(
+    () => computeAchievements(achievements, scope),
+    [achievements, scope],
+  );
+
+  const visibleRows = useMemo(() => {
+    const filtered =
+      typeFilter === "all"
+        ? allRows
+        : typeFilter === "anniversaries"
+          ? allRows.filter((r) => r.type === "anniversary")
+          : allRows.filter((r) => r.type === typeFilter);
+
+    // Anniversaries first (by days_until ASC), then count milestones (by remaining ASC), then name
+    return [...filtered].sort((a, b) => {
+      const aIsAnniv = a.type === "anniversary" ? 0 : 1;
+      const bIsAnniv = b.type === "anniversary" ? 0 : 1;
+      if (aIsAnniv !== bIsAnniv) return aIsAnniv - bIsAnniv;
+      if (a.urgency !== b.urgency) return a.urgency - b.urgency;
+      return a.f3_name.localeCompare(b.f3_name);
+    });
+  }, [allRows, typeFilter]);
+
+  // Compute year for anniversary rows: use fng_date from achievements
+  // We annotate anniversary rows with the year at display time.
+  const anniversaryYears = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const pax of achievements) {
+      if (pax.fng_date && pax.next_anniversary_date) {
+        const fng = new Date(pax.fng_date);
+        const anniv = new Date(pax.next_anniversary_date);
+        const year = anniv.getUTCFullYear() - fng.getUTCFullYear();
+        map.set(pax.user_id, year);
+      }
+    }
+    return map;
+  }, [achievements]);
+
+  return (
+    <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
+      <CardHeader className="flex justify-between items-center px-6">
+        <div className="flex items-center justify-between w-full gap-3">
+          <div className="font-semibold text-xl">Achievements</div>
+          <div className="flex items-center gap-2 flex-wrap justify-end">
+            <Tabs
+              aria-label="Select achievement scope"
+              selectedKey={scope}
+              onSelectionChange={(key) => setScope(key as AchievementScope)}
+              size="sm"
+              radius="sm"
+              variant="bordered"
+              color="secondary"
+            >
+              <Tab key="region" title="Region" />
+              <Tab key="nation" title="Nation" />
+            </Tabs>
+            <Dropdown>
+              <DropdownTrigger>
+                <Button size="md" variant="bordered" color="default">
+                  {
+                    {
+                      all: "All",
+                      posts: "Posts",
+                      qs: "Qs",
+                      anniversaries: "Anniversaries",
+                    }[typeFilter]
+                  }
+                </Button>
+              </DropdownTrigger>
+              <DropdownMenu
+                aria-label="Filter achievement type"
+                selectionMode="single"
+                selectedKeys={new Set([typeFilter])}
+                onSelectionChange={(keys) => {
+                  const first = Array.from(keys as Set<string>)[0];
+                  setTypeFilter((first ?? "all") as AchievementType);
+                }}
+              >
+                <DropdownItem key="all">All</DropdownItem>
+                <DropdownItem key="posts">Posts</DropdownItem>
+                <DropdownItem key="qs">Qs</DropdownItem>
+                <DropdownItem key="anniversaries">Anniversaries</DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+          </div>
+        </div>
+      </CardHeader>
+      <Divider />
+      <CardBody className="px-6">
+        <ScrollShadow className="h-[1105px]">
+          <div className="space-y-1 text-sm">
+            {visibleRows.length === 0 ? (
+              <div className="italic text-default-500 text-sm py-2">
+                No upcoming achievements for this view.
+              </div>
+            ) : (
+              visibleRows.map((row, idx) => {
+                // For anniversary rows, replace the computed `current` with the actual year
+                const displayRow =
+                  row.type === "anniversary"
+                    ? {
+                        ...row,
+                        current:
+                          anniversaryYears.get(row.user_id) ?? row.current,
+                      }
+                    : row;
+
+                return (
+                  <div
+                    key={`${row.user_id}-${row.type}-${idx}`}
+                    className="flex justify-between items-center py-1 pb-2 border-b light:border-black/10 dark:border-white/10"
+                  >
+                    <div className="flex items-center gap-2 text-sm min-w-0">
+                      <Avatar
+                        alt={row.f3_name ?? row.user_id.toString()}
+                        className="flex-shrink-0"
+                        size="sm"
+                        src={row.avatar_url}
+                      />
+                      <div className="flex flex-col gap-0.5 min-w-0">
+                        <Link
+                          className="text-sm"
+                          color="primary"
+                          href={`/stats/pax/${row.user_id}${filters ? `?${filters}` : ""}`}
+                        >
+                          {row.f3_name ?? row.user_id.toString()}
+                        </Link>
+                        <span className="text-xs text-default-500 truncate">
+                          {milestoneDescription(displayRow)}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="flex-shrink-0 ml-3">
+                      {typeChip(row.type)}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </ScrollShadow>
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/components/region/PageWrapper.tsx
+++ b/src/components/region/PageWrapper.tsx
@@ -18,6 +18,7 @@ import {
   EventUpcoming,
   RegionInfo,
   ChartData,
+  RegionAchievementPax,
 } from "@/lib/types";
 import { SummaryCard } from "./SummaryCard";
 import { LeadersCard } from "../leaders";
@@ -27,6 +28,7 @@ import { EventsCard } from "../events";
 import { Filter } from "../pageFilter";
 import { useMemo } from "react";
 import { ChartCard } from "./ChartsCard";
+import { AchievementsCard } from "./AchievementsCard";
 
 type RegionalPageWrapperProps = {
   region_id: number;
@@ -37,6 +39,7 @@ type RegionalPageWrapperProps = {
   region_upcoming: EventUpcoming[] | null;
   region_events: EventData[];
   region_charts: ChartData[];
+  region_achievements: RegionAchievementPax[];
   searchParams: {
     categoryIds?: string | string[];
     categoryMode?: string;
@@ -100,6 +103,7 @@ export function RegionalPageWrapper({
   region_upcoming,
   region_events,
   region_charts,
+  region_achievements,
   searchParams,
 }: RegionalPageWrapperProps) {
   // Memoized query-string passed to events + filter components.
@@ -139,16 +143,23 @@ export function RegionalPageWrapper({
       <div className="grid grid-cols-1 gap-6 w-full max-w-6xl hidden">
         <ChartCard charts={region_charts || []} />
       </div>
-      {/* Kotters + upcoming events */}
+      {/* Upcoming achievements */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 w-full max-w-6xl">
-        <KotterCard
-          kotters={region_kotter || []}
+        <AchievementsCard
+          achievements={region_achievements || []}
           filters={eventsFiltersQuery}
         />
-        <UpcomingEventsCard
-          events={region_upcoming || []}
-          filters={eventsFiltersQuery}
-        />
+        {/* Kotters + upcoming events */}
+        <div className="grid grid-cols-1 gap-6 w-full max-w-6xl">
+          <KotterCard
+            kotters={region_kotter || []}
+            filters={eventsFiltersQuery}
+          />
+          <UpcomingEventsCard
+            events={region_upcoming || []}
+            filters={eventsFiltersQuery}
+          />
+        </div>
       </div>
       {/* Event list */}
       <div className="grid grid-cols-1 gap-6 w-full max-w-6xl">

--- a/src/components/search-modal.tsx
+++ b/src/components/search-modal.tsx
@@ -57,6 +57,7 @@ export default function SearchModal({
 }: SearchModalProps) {
   const router = useRouter();
   const [query, setQuery] = useState("");
+  const [includeInactive, setIncludeInactive] = useState(false);
   const [paxResults, setPaxResults] = useState<PAXInfo[]>([]);
   const [regionResults, setRegionResults] = useState<RegionInfo[]>([]);
   const [aoResults, setAoResults] = useState<AOInfo[]>([]);
@@ -106,6 +107,7 @@ export default function SearchModal({
   useEffect(() => {
     if (!isOpen) {
       setQuery("");
+      setIncludeInactive(false);
       setPaxResults([]);
       setRegionResults([]);
       setAoResults([]);
@@ -140,13 +142,14 @@ export default function SearchModal({
 
     let cancelled = false;
     const encoded = encodeURIComponent(q);
+    const inactiveParam = includeInactive ? "&includeInactive=true" : "";
 
     const t = setTimeout(() => {
       fetchJson<PAXInfo>(`/api/pax/list?q=${encoded}`)
         .then((data) => {
           if (!cancelled) setPaxResults(data);
         })
-        .catch((err) => {
+        .catch((err: unknown) => {
           if (!cancelled)
             setPaxError(err instanceof Error ? err.message : "Search failed");
         })
@@ -154,11 +157,11 @@ export default function SearchModal({
           if (!cancelled) setPaxLoading(false);
         });
 
-      fetchJson<RegionInfo>(`/api/region/list?q=${encoded}`)
+      fetchJson<RegionInfo>(`/api/region/list?q=${encoded}${inactiveParam}`)
         .then((data) => {
           if (!cancelled) setRegionResults(data);
         })
-        .catch((err) => {
+        .catch((err: unknown) => {
           if (!cancelled)
             setRegionError(
               err instanceof Error ? err.message : "Search failed",
@@ -168,11 +171,11 @@ export default function SearchModal({
           if (!cancelled) setRegionLoading(false);
         });
 
-      fetchJson<AOInfo>(`/api/ao/list?q=${encoded}`)
+      fetchJson<AOInfo>(`/api/ao/list?q=${encoded}${inactiveParam}`)
         .then((data) => {
           if (!cancelled) setAoResults(data);
         })
-        .catch((err) => {
+        .catch((err: unknown) => {
           if (!cancelled)
             setAoError(err instanceof Error ? err.message : "Search failed");
         })
@@ -185,7 +188,7 @@ export default function SearchModal({
       cancelled = true;
       clearTimeout(t);
     };
-  }, [query]);
+  }, [query, includeInactive]);
 
   const navigate = useCallback(
     (result: SearchResult) => {
@@ -251,6 +254,23 @@ export default function SearchModal({
               />
             </div>
 
+            {/* Include inactive checkbox */}
+            <div className="flex items-center gap-2 px-4 pb-2">
+              <input
+                id="include-inactive"
+                type="checkbox"
+                checked={includeInactive}
+                onChange={(e) => setIncludeInactive(e.target.checked)}
+                className="h-3.5 w-3.5 cursor-pointer accent-primary"
+              />
+              <label
+                htmlFor="include-inactive"
+                className="text-xs text-default-400 cursor-pointer select-none"
+              >
+                Include inactive search results
+              </label>
+            </div>
+
             {/* Jump-to-section bar — only when multiple sections have results */}
             {jumpLinks.length > 1 && (
               <div className="flex items-center gap-1 px-4 pb-2 text-xs text-default-400">
@@ -314,12 +334,19 @@ export default function SearchModal({
                         alt={region.region_name}
                         size="sm"
                         src={region.logo_url ?? undefined}
-                        className="flex-shrink-0"
+                        className={`flex-shrink-0 ${!region.is_active ? "opacity-50" : ""}`}
                       />
                       <div className="flex flex-col min-w-0">
-                        <span className="text-sm font-medium truncate">
-                          {region.region_name}
-                        </span>
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className={`text-sm font-medium truncate ${!region.is_active ? "text-default-400" : ""}`}>
+                            {region.region_name}
+                          </span>
+                          {!region.is_active && (
+                            <span className="flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded bg-default-100 text-default-400 uppercase tracking-wide">
+                              Inactive
+                            </span>
+                          )}
+                        </div>
                       </div>
                     </ResultItem>
                   );
@@ -350,12 +377,19 @@ export default function SearchModal({
                         alt={ao.ao_name}
                         size="sm"
                         src={ao.logo_url ?? undefined}
-                        className="flex-shrink-0"
+                        className={`flex-shrink-0 ${!ao.is_active ? "opacity-50" : ""}`}
                       />
                       <div className="flex flex-col min-w-0">
-                        <span className="text-sm font-medium truncate">
-                          {ao.ao_name}
-                        </span>
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className={`text-sm font-medium truncate ${!ao.is_active ? "text-default-400" : ""}`}>
+                            {ao.ao_name}
+                          </span>
+                          {!ao.is_active && (
+                            <span className="flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded bg-default-100 text-default-400 uppercase tracking-wide">
+                              Inactive
+                            </span>
+                          )}
+                        </div>
                         <span className="text-xs text-default-400 truncate">
                           {ao.region_name}
                         </span>

--- a/src/components/search-modal.tsx
+++ b/src/components/search-modal.tsx
@@ -315,7 +315,9 @@ export default function SearchModal({
                       />
                       <div className="flex flex-col min-w-0">
                         <div className="flex items-center gap-2 min-w-0">
-                          <span className={`text-sm font-medium truncate ${!region.is_active ? "text-default-400" : ""}`}>
+                          <span
+                            className={`text-sm font-medium truncate ${!region.is_active ? "text-default-400" : ""}`}
+                          >
                             {region.region_name}
                           </span>
                           {!region.is_active && (
@@ -357,7 +359,9 @@ export default function SearchModal({
                       />
                       <div className="flex flex-col min-w-0">
                         <div className="flex items-center gap-2 min-w-0">
-                          <span className={`text-sm font-medium truncate ${!ao.is_active ? "text-default-400" : ""}`}>
+                          <span
+                            className={`text-sm font-medium truncate ${!ao.is_active ? "text-default-400" : ""}`}
+                          >
                             {ao.ao_name}
                           </span>
                           {!ao.is_active && (

--- a/src/components/search-modal.tsx
+++ b/src/components/search-modal.tsx
@@ -18,6 +18,12 @@ type SearchResult =
   | { kind: "region"; item: RegionInfo }
   | { kind: "ao"; item: AOInfo };
 
+type SearchPayload = {
+  regions: RegionInfo[];
+  aos: AOInfo[];
+  pax: PAXInfo[];
+};
+
 function routeForResult(result: SearchResult): string {
   switch (result.kind) {
     case "pax":
@@ -29,7 +35,7 @@ function routeForResult(result: SearchResult): string {
   }
 }
 
-async function fetchJson<T>(url: string): Promise<T[]> {
+async function fetchSearchResults(url: string): Promise<SearchPayload> {
   const res = await fetch(url, {
     method: "GET",
     headers: { Accept: "application/json" },
@@ -40,9 +46,7 @@ async function fetchJson<T>(url: string): Promise<T[]> {
       (body as { error?: string }).error || `Request failed: ${res.status}`,
     );
   }
-  const data = await res.json();
-  if (!Array.isArray(data)) throw new Error("Unexpected response format");
-  return data as T[];
+  return res.json() as Promise<SearchPayload>;
 }
 
 const SECTION_IDS = {
@@ -61,12 +65,8 @@ export default function SearchModal({
   const [paxResults, setPaxResults] = useState<PAXInfo[]>([]);
   const [regionResults, setRegionResults] = useState<RegionInfo[]>([]);
   const [aoResults, setAoResults] = useState<AOInfo[]>([]);
-  const [paxLoading, setPaxLoading] = useState(false);
-  const [regionLoading, setRegionLoading] = useState(false);
-  const [aoLoading, setAoLoading] = useState(false);
-  const [paxError, setPaxError] = useState<string | null>(null);
-  const [regionError, setRegionError] = useState<string | null>(null);
-  const [aoError, setAoError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -81,7 +81,6 @@ export default function SearchModal({
     return items;
   }, [regionResults, aoResults, paxResults]);
 
-  const isLoading = paxLoading || regionLoading || aoLoading;
   const hasQuery = query.trim().length >= 2;
   const hasResults = allResults.length > 0;
 
@@ -111,33 +110,26 @@ export default function SearchModal({
       setPaxResults([]);
       setRegionResults([]);
       setAoResults([]);
-      setPaxError(null);
-      setRegionError(null);
-      setAoError(null);
+      setSearchError(null);
       setFocusedIndex(-1);
     }
   }, [isOpen]);
 
-  // Debounced search — fires 3 parallel fetches.
+  // Debounced unified search — single API call.
   useEffect(() => {
     const q = query.trim();
     if (q.length < 2) {
       setPaxResults([]);
       setRegionResults([]);
       setAoResults([]);
-      setPaxLoading(false);
-      setRegionLoading(false);
-      setAoLoading(false);
-      setPaxError(null);
-      setRegionError(null);
-      setAoError(null);
+      setLoading(false);
+      setSearchError(null);
       setFocusedIndex(-1);
       return;
     }
 
-    setPaxLoading(true);
-    setRegionLoading(true);
-    setAoLoading(true);
+    setLoading(true);
+    setSearchError(null);
     setFocusedIndex(-1);
 
     let cancelled = false;
@@ -145,42 +137,22 @@ export default function SearchModal({
     const inactiveParam = includeInactive ? "&includeInactive=true" : "";
 
     const t = setTimeout(() => {
-      fetchJson<PAXInfo>(`/api/pax/list?q=${encoded}`)
+      fetchSearchResults(`/api/search?q=${encoded}${inactiveParam}`)
         .then((data) => {
-          if (!cancelled) setPaxResults(data);
+          if (!cancelled) {
+            setRegionResults(data.regions);
+            setAoResults(data.aos);
+            setPaxResults(data.pax);
+          }
         })
         .catch((err: unknown) => {
           if (!cancelled)
-            setPaxError(err instanceof Error ? err.message : "Search failed");
-        })
-        .finally(() => {
-          if (!cancelled) setPaxLoading(false);
-        });
-
-      fetchJson<RegionInfo>(`/api/region/list?q=${encoded}${inactiveParam}`)
-        .then((data) => {
-          if (!cancelled) setRegionResults(data);
-        })
-        .catch((err: unknown) => {
-          if (!cancelled)
-            setRegionError(
+            setSearchError(
               err instanceof Error ? err.message : "Search failed",
             );
         })
         .finally(() => {
-          if (!cancelled) setRegionLoading(false);
-        });
-
-      fetchJson<AOInfo>(`/api/ao/list?q=${encoded}${inactiveParam}`)
-        .then((data) => {
-          if (!cancelled) setAoResults(data);
-        })
-        .catch((err: unknown) => {
-          if (!cancelled)
-            setAoError(err instanceof Error ? err.message : "Search failed");
-        })
-        .finally(() => {
-          if (!cancelled) setAoLoading(false);
+          if (!cancelled) setLoading(false);
         });
     }, 600);
 
@@ -245,7 +217,7 @@ export default function SearchModal({
                 isClearable
                 onClear={() => setQuery("")}
                 startContent={
-                  isLoading ? (
+                  loading ? (
                     <Spinner size="sm" color="primary" />
                   ) : (
                     <SearchIcon className="h-4 w-4 text-default-400" />
@@ -303,9 +275,15 @@ export default function SearchModal({
                 </div>
               )}
 
-              {hasQuery && !isLoading && !hasResults && (
+              {hasQuery && !loading && !hasResults && !searchError && (
                 <div className="px-4 py-8 text-center text-sm text-default-400">
                   No results found
+                </div>
+              )}
+
+              {hasQuery && searchError && (
+                <div className="px-4 py-4 text-center text-sm text-danger-500">
+                  {searchError}
                 </div>
               )}
 
@@ -313,9 +291,8 @@ export default function SearchModal({
               <ResultSection
                 id={SECTION_IDS.regions}
                 title="REGIONS"
-                loading={regionLoading}
-                error={regionError}
-                empty={hasQuery && !regionLoading && regionResults.length === 0}
+                loading={loading}
+                empty={hasQuery && !loading && regionResults.length === 0}
               >
                 {regionResults.map((region) => {
                   const idx = allResults.findIndex(
@@ -357,9 +334,8 @@ export default function SearchModal({
               <ResultSection
                 id={SECTION_IDS.aos}
                 title="AOs"
-                loading={aoLoading}
-                error={aoError}
-                empty={hasQuery && !aoLoading && aoResults.length === 0}
+                loading={loading}
+                empty={hasQuery && !loading && aoResults.length === 0}
                 showDivider
               >
                 {aoResults.map((ao) => {
@@ -403,9 +379,8 @@ export default function SearchModal({
               <ResultSection
                 id={SECTION_IDS.pax}
                 title="PAX"
-                loading={paxLoading}
-                error={paxError}
-                empty={hasQuery && !paxLoading && paxResults.length === 0}
+                loading={loading}
+                empty={hasQuery && !loading && paxResults.length === 0}
                 showDivider
               >
                 {paxResults.map((pax) => {
@@ -486,7 +461,6 @@ function ResultSection({
   id,
   title,
   loading,
-  error,
   empty,
   showDivider = false,
   children,
@@ -494,7 +468,6 @@ function ResultSection({
   id: string;
   title: string;
   loading: boolean;
-  error: string | null;
   empty: boolean;
   showDivider?: boolean;
   children: React.ReactNode;
@@ -503,8 +476,8 @@ function ResultSection({
     ? children.length > 0
     : !!children;
 
-  if (!loading && !error && empty) return null;
-  if (!loading && !error && !hasChildren) return null;
+  if (!loading && empty) return null;
+  if (!loading && !hasChildren) return null;
 
   return (
     <div
@@ -514,9 +487,6 @@ function ResultSection({
       <div className="px-4 py-1 text-xs font-semibold tracking-widest text-default-400 uppercase">
         {title}
       </div>
-      {error && (
-        <div className="px-4 py-2 text-xs text-danger-500">{error}</div>
-      )}
       {loading && !hasChildren && (
         <div className="flex items-center gap-2 px-4 py-3 text-xs text-default-400">
           <Spinner size="sm" /> Searching...

--- a/src/lib/bq/aos.ts
+++ b/src/lib/bq/aos.ts
@@ -406,6 +406,7 @@ export async function getPageData(
 export async function searchAOsByName(
   q: string,
   userIdentifier?: string,
+  includeInactive = false,
 ): Promise<AOInfo[]> {
   const term = (q || "").trim();
   if (term.length < 2) return [];
@@ -423,7 +424,7 @@ export async function searchAOsByName(
     FROM pv_aos
     WHERE ao_name IS NOT NULL
       AND LOWER(ao_name) LIKE '%${escapedTerm}%'
-      AND is_active = TRUE
+      ${includeInactive ? "" : "AND is_active = TRUE"}
     ORDER BY ao_name
     LIMIT 50
   `;

--- a/src/lib/bq/regions.ts
+++ b/src/lib/bq/regions.ts
@@ -7,6 +7,7 @@ import {
   EventUpcoming,
   RegionKotterList,
   ChartData,
+  RegionAchievementPax,
 } from "@/lib/types";
 
 /**
@@ -352,6 +353,7 @@ export async function getPageData(
         unique_q_count: number;
       }[]
     | null;
+  achievements: RegionAchievementPax[] | null;
 }> {
   // Build WHERE clause from common filters (region-scoped).
   const whereSql = buildEventsWhereSql(regionId, opts);
@@ -453,6 +455,85 @@ export async function getPageData(
           ON li.user_id = a.user_id
         WHERE a.user_id IS NOT NULL${eventsFilterAndSql}
         GROUP BY a.user_id
+      ),
+
+      -- ── Achievements ────────────────────────────────────────────────────────
+      -- Milestone thresholds shared across posts and Qs
+      achievement_thresholds AS (
+        SELECT t FROM UNNEST([25, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]) AS t
+      ),
+
+      -- All home-region PAX from pv_pax (source of truth for membership + FNG override)
+      achievement_pax_base AS (
+        SELECT user_id, f3_name, avatar_url, start_date_override
+        FROM pv_pax
+        WHERE home_region_id = ${regionId}
+      ),
+
+      -- Single pass over pv_events for all four count dimensions + first_event_date
+      -- (all-time, no date filter so milestones reflect career totals)
+      achievement_event_counts AS (
+        SELECT
+          a.user_id,
+          COUNT(DISTINCT IF(e.region_org_id = ${regionId}, e.event_id, NULL)) AS region_posts,
+          COUNT(DISTINCT IF(e.region_org_id = ${regionId} AND a.q_ind = 1, e.event_id, NULL)) AS region_qs,
+          COUNT(DISTINCT e.event_id) AS all_posts,
+          COUNT(DISTINCT IF(a.q_ind = 1, e.event_id, NULL)) AS all_qs,
+          MIN(e.event_date) AS first_event_date
+        FROM pv_events e
+        JOIN UNNEST(e.attendance) a ON TRUE
+        JOIN achievement_pax_base pb ON pb.user_id = a.user_id
+        GROUP BY a.user_id
+      ),
+
+      -- Combine pv_pax fields with computed counts; resolve fng_date using override.
+      -- Mirrors pax.ts: IFNULL(CAST(start_date_override AS STRING), CAST(first_event_date AS STRING))
+      -- fng_date is kept as STRING so DATE(fng_date) can be used for anniversary math.
+      achievement_pax AS (
+        SELECT
+          pb.user_id,
+          pb.f3_name,
+          pb.avatar_url,
+          COALESCE(ec.region_posts, 0) AS region_posts,
+          COALESCE(ec.region_qs, 0) AS region_qs,
+          COALESCE(ec.all_posts, 0) AS all_posts,
+          COALESCE(ec.all_qs, 0) AS all_qs,
+          IFNULL(
+            CAST(pb.start_date_override AS STRING),
+            CAST(ec.first_event_date AS STRING)
+          ) AS fng_date
+        FROM achievement_pax_base pb
+        LEFT JOIN achievement_event_counts ec ON ec.user_id = pb.user_id
+      ),
+
+      -- Cross with thresholds to find next milestone per count dimension.
+      -- Also computes next_anniversary_date correctly:
+      --   use this year's month/day; if already past, use next year.
+      -- This avoids DATE_DIFF(YEAR) which counts calendar boundaries, not completed anniversaries.
+      achievement_pax_milestones AS (
+        SELECT
+          p.user_id, p.f3_name, p.avatar_url,
+          p.region_posts, p.region_qs, p.all_posts, p.all_qs, p.fng_date,
+          MIN(CASE WHEN t.t > p.region_posts THEN t.t END) AS next_region_post_milestone,
+          MIN(CASE WHEN t.t > p.all_posts    THEN t.t END) AS next_nation_post_milestone,
+          MIN(CASE WHEN t.t > p.region_qs   THEN t.t END) AS next_region_q_milestone,
+          MIN(CASE WHEN t.t > p.all_qs      THEN t.t END) AS next_nation_q_milestone,
+          -- Use DATE_ADD (not EXTRACT) so leap-year FNG dates (Feb 29) roll safely to Feb 28.
+          -- year_diff = calendar years between FNG year and today's year.
+          -- "this year's anniversary" = DATE_ADD(fng_date, INTERVAL year_diff YEAR).
+          -- If that date has already passed, add one more year.
+          IF(p.fng_date IS NOT NULL,
+            CASE
+              WHEN DATE_ADD(DATE(p.fng_date), INTERVAL (EXTRACT(YEAR FROM CURRENT_DATE()) - EXTRACT(YEAR FROM DATE(p.fng_date))) YEAR) >= CURRENT_DATE()
+              THEN DATE_ADD(DATE(p.fng_date), INTERVAL (EXTRACT(YEAR FROM CURRENT_DATE()) - EXTRACT(YEAR FROM DATE(p.fng_date))) YEAR)
+              ELSE DATE_ADD(DATE(p.fng_date), INTERVAL (EXTRACT(YEAR FROM CURRENT_DATE()) - EXTRACT(YEAR FROM DATE(p.fng_date)) + 1) YEAR)
+            END,
+            NULL
+          ) AS next_anniversary_date
+        FROM achievement_pax p
+        CROSS JOIN achievement_thresholds t
+        GROUP BY p.user_id, p.f3_name, p.avatar_url,
+                 p.region_posts, p.region_qs, p.all_posts, p.all_qs, p.fng_date
       )
     SELECT
       -- Region info as a STRUCT
@@ -587,6 +668,35 @@ export async function getPageData(
         WHERE home_region_id = ${regionId}
       ) AS kotter,
 
+      -- Achievements: PAX approaching post/Q milestones or with upcoming anniversaries
+      (
+        SELECT ARRAY_AGG(
+          STRUCT(
+            user_id, f3_name, avatar_url,
+            region_posts, region_qs, all_posts, all_qs,
+            next_region_post_milestone,
+            next_nation_post_milestone,
+            next_region_q_milestone,
+            next_nation_q_milestone,
+            fng_date,
+            CAST(next_anniversary_date AS STRING) AS next_anniversary_date,
+            IF(next_anniversary_date IS NOT NULL,
+              DATE_DIFF(next_anniversary_date, CURRENT_DATE(), DAY),
+              NULL
+            ) AS days_until_anniversary
+          )
+          ORDER BY f3_name ASC
+        )
+        FROM achievement_pax_milestones
+        WHERE
+          ((next_region_post_milestone IS NOT NULL AND next_region_post_milestone - region_posts <= 5)
+          OR (next_nation_post_milestone IS NOT NULL AND next_nation_post_milestone - all_posts <= 5)
+          OR (next_region_q_milestone IS NOT NULL AND next_region_q_milestone - region_qs <= 3)
+          OR (next_nation_q_milestone IS NOT NULL AND next_nation_q_milestone - all_qs <= 3)
+          OR (next_anniversary_date IS NOT NULL AND DATE_DIFF(next_anniversary_date, CURRENT_DATE(), DAY) BETWEEN 0 AND 14))
+          AND (region_posts > 10) -- Filter out very new PAX with no significant activity (adjust threshold as needed)
+      ) AS achievements,
+
       -- Charting: ${chartGranularity} aggregation with gap-filling
       (
         WITH
@@ -653,6 +763,7 @@ export async function getPageData(
     upcoming: EventUpcoming[];
     kotter: RegionKotterList[];
     charts: ChartData[];
+    achievements: RegionAchievementPax[];
   }>(query, userIdentifier, `fetch region data for region ${regionId}`);
 
   return {
@@ -663,5 +774,6 @@ export async function getPageData(
     upcoming: results?.[0]?.upcoming || null,
     kotter: results?.[0]?.kotter || null,
     charts: results?.[0]?.charts || null,
+    achievements: results?.[0]?.achievements || null,
   };
 }

--- a/src/lib/bq/regions.ts
+++ b/src/lib/bq/regions.ts
@@ -301,6 +301,7 @@ export async function getEvents(
 export async function searchRegionsByName(
   q: string,
   userIdentifier?: string,
+  includeInactive = false,
 ): Promise<RegionInfo[]> {
   // Normalize and guard against overly-broad queries.
   const term = (q || "").trim();
@@ -319,7 +320,7 @@ export async function searchRegionsByName(
     FROM pv_regions
     WHERE region_name IS NOT NULL
       AND LOWER(region_name) LIKE '%${escapedTerm}%'
-      AND is_active = TRUE
+      ${includeInactive ? "" : "AND is_active = TRUE"}
     ORDER BY region_name
     LIMIT 50
   `;

--- a/src/lib/bq/regions.ts
+++ b/src/lib/bq/regions.ts
@@ -479,7 +479,8 @@ export async function getPageData(
           COUNT(DISTINCT IF(e.region_org_id = ${regionId} AND a.q_ind = 1, e.event_id, NULL)) AS region_qs,
           COUNT(DISTINCT e.event_id) AS all_posts,
           COUNT(DISTINCT IF(a.q_ind = 1, e.event_id, NULL)) AS all_qs,
-          MIN(e.event_date) AS first_event_date
+          MIN(e.event_date) AS first_event_date,
+          MAX(IF(e.region_org_id = ${regionId}, e.event_date, NULL)) AS last_region_event_date
         FROM pv_events e
         JOIN UNNEST(e.attendance) a ON TRUE
         JOIN achievement_pax_base pb ON pb.user_id = a.user_id
@@ -501,7 +502,8 @@ export async function getPageData(
           IFNULL(
             CAST(pb.start_date_override AS STRING),
             CAST(ec.first_event_date AS STRING)
-          ) AS fng_date
+          ) AS fng_date,
+          ec.last_region_event_date
         FROM achievement_pax_base pb
         LEFT JOIN achievement_event_counts ec ON ec.user_id = pb.user_id
       ),
@@ -513,7 +515,7 @@ export async function getPageData(
       achievement_pax_milestones AS (
         SELECT
           p.user_id, p.f3_name, p.avatar_url,
-          p.region_posts, p.region_qs, p.all_posts, p.all_qs, p.fng_date,
+          p.region_posts, p.region_qs, p.all_posts, p.all_qs, p.fng_date, p.last_region_event_date,
           MIN(CASE WHEN t.t > p.region_posts THEN t.t END) AS next_region_post_milestone,
           MIN(CASE WHEN t.t > p.all_posts    THEN t.t END) AS next_nation_post_milestone,
           MIN(CASE WHEN t.t > p.region_qs   THEN t.t END) AS next_region_q_milestone,
@@ -533,7 +535,7 @@ export async function getPageData(
         FROM achievement_pax p
         CROSS JOIN achievement_thresholds t
         GROUP BY p.user_id, p.f3_name, p.avatar_url,
-                 p.region_posts, p.region_qs, p.all_posts, p.all_qs, p.fng_date
+                 p.region_posts, p.region_qs, p.all_posts, p.all_qs, p.fng_date, p.last_region_event_date
       )
     SELECT
       -- Region info as a STRUCT
@@ -679,6 +681,7 @@ export async function getPageData(
             next_region_q_milestone,
             next_nation_q_milestone,
             fng_date,
+            CAST(last_region_event_date AS STRING) AS last_region_event_date,
             CAST(next_anniversary_date AS STRING) AS next_anniversary_date,
             IF(next_anniversary_date IS NOT NULL,
               DATE_DIFF(next_anniversary_date, CURRENT_DATE(), DAY),
@@ -689,12 +692,26 @@ export async function getPageData(
         )
         FROM achievement_pax_milestones
         WHERE
-          ((next_region_post_milestone IS NOT NULL AND next_region_post_milestone - region_posts <= 5)
-          OR (next_nation_post_milestone IS NOT NULL AND next_nation_post_milestone - all_posts <= 5)
-          OR (next_region_q_milestone IS NOT NULL AND next_region_q_milestone - region_qs <= 3)
-          OR (next_nation_q_milestone IS NOT NULL AND next_nation_q_milestone - all_qs <= 3)
-          OR (next_anniversary_date IS NOT NULL AND DATE_DIFF(next_anniversary_date, CURRENT_DATE(), DAY) BETWEEN 0 AND 14))
-          AND (region_posts > 10) -- Filter out very new PAX with no significant activity (adjust threshold as needed)
+          (
+            -- 1 away from any milestone — always show regardless of recent activity
+            (next_region_post_milestone IS NOT NULL AND next_region_post_milestone - region_posts = 1)
+            OR (next_nation_post_milestone IS NOT NULL AND next_nation_post_milestone - all_posts = 1)
+            OR (next_region_q_milestone IS NOT NULL AND next_region_q_milestone - region_qs = 1)
+            OR (next_nation_q_milestone IS NOT NULL AND next_nation_q_milestone - all_qs = 1)
+            -- Within milestone range and active in the last 30 days
+            OR (
+              last_region_event_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+              AND (
+                (next_region_post_milestone IS NOT NULL AND next_region_post_milestone - region_posts <= 5)
+                OR (next_nation_post_milestone IS NOT NULL AND next_nation_post_milestone - all_posts <= 5)
+                OR (next_region_q_milestone IS NOT NULL AND next_region_q_milestone - region_qs <= 3)
+                OR (next_nation_q_milestone IS NOT NULL AND next_nation_q_milestone - all_qs <= 3)
+              )
+            )
+            -- Upcoming anniversary (no activity gate, but min 25 region posts)
+            OR (next_anniversary_date IS NOT NULL AND DATE_DIFF(next_anniversary_date, CURRENT_DATE(), DAY) BETWEEN 0 AND 14 AND region_posts >= 25)
+          )
+          AND (region_posts > 10) -- Filter out very new PAX with no significant activity
       ) AS achievements,
 
       -- Charting: ${chartGranularity} aggregation with gap-filling

--- a/src/lib/bq/search.ts
+++ b/src/lib/bq/search.ts
@@ -1,0 +1,70 @@
+import { queryBigQuery } from "@/lib/db";
+import { RegionInfo, AOInfo, PAXInfo } from "@/lib/types";
+
+export type SearchAllResult = {
+  regions: RegionInfo[];
+  aos: AOInfo[];
+  pax: PAXInfo[];
+};
+
+type SearchAllRow = {
+  regions: RegionInfo[] | null;
+  aos: AOInfo[] | null;
+  pax: PAXInfo[] | null;
+};
+
+export async function searchAll(
+  q: string,
+  userIdentifier?: string,
+  includeInactive = false,
+): Promise<SearchAllResult> {
+  const term = (q || "").trim();
+  if (term.length < 2) return { regions: [], aos: [], pax: [] };
+
+  // Escape single quotes to prevent SQL injection via LIKE.
+  const escapedTerm = term.replace(/'/g, "''").toLowerCase();
+  const activeFilter = includeInactive ? "" : "AND is_active = TRUE";
+
+  // Single query — each subquery returns an ARRAY of STRUCTs so the entire
+  // result comes back as one BigQuery row with three array columns.
+  // ARRAY_AGG returns NULL when no rows match; we coalesce to [] in JS below.
+  const query = `-- UNIFIED SEARCH
+    SELECT
+      (
+        SELECT ARRAY_AGG(STRUCT(region_id, region_name, logo_url, is_active)
+               ORDER BY region_name LIMIT 50)
+        FROM pv_regions
+        WHERE region_name IS NOT NULL
+          AND LOWER(region_name) LIKE '%${escapedTerm}%'
+          ${activeFilter}
+      ) AS regions,
+      (
+        SELECT ARRAY_AGG(STRUCT(ao_id, ao_name, region_id, region_name, logo_url, is_active)
+               ORDER BY ao_name LIMIT 50)
+        FROM pv_aos
+        WHERE ao_name IS NOT NULL
+          AND LOWER(ao_name) LIKE '%${escapedTerm}%'
+          ${activeFilter}
+      ) AS aos,
+      (
+        SELECT ARRAY_AGG(STRUCT(user_id, f3_name, home_region_id, home_region_name, avatar_url, status)
+               ORDER BY f3_name LIMIT 50)
+        FROM pv_pax
+        WHERE f3_name IS NOT NULL
+          AND LOWER(f3_name) LIKE '%${escapedTerm}%'
+      ) AS pax
+  `;
+
+  const rows = await queryBigQuery<SearchAllRow>(
+    query,
+    userIdentifier,
+    `unified search: ${q}`,
+  );
+
+  const row = rows[0];
+  return {
+    regions: row?.regions ?? [],
+    aos: row?.aos ?? [],
+    pax: row?.pax ?? [],
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -113,6 +113,7 @@ export interface RegionData {
   upcoming: EventUpcoming[] | null; // List of upcoming events in the region
   kotter: RegionKotterList[] | null; // List of Kotter events in the region
   charts: ChartData[] | null; // List of chart data points for the region
+  achievements: RegionAchievementPax[] | null; // PAX approaching milestones or with upcoming anniversaries
 }
 
 /* USED ONLY FOR REGION INFO */
@@ -136,6 +137,24 @@ export interface RegionSummary {
   unique_qs: number; // Number of unique Qs (leaders) who have led events in the region
   fng_count: number; // Total number of first-time participants (FNGs) in the region
   pax_count_average: number; // Average number of participants (pax) per event in the region
+}
+
+/* USED FOR REGION UPCOMING ACHIEVEMENTS */
+export interface RegionAchievementPax {
+  user_id: number; // Unique identifier for the user
+  f3_name: string; // F3 name (nickname) of the user
+  avatar_url?: string; // Optional URL to the user's avatar image
+  region_posts: number; // Total posts (events attended) in this region
+  region_qs: number; // Total Qs led in this region
+  all_posts: number; // Total posts across all regions
+  all_qs: number; // Total Qs across all regions
+  next_region_post_milestone: number | null; // Next post milestone in this region
+  next_nation_post_milestone: number | null; // Next post milestone across all regions
+  next_region_q_milestone: number | null; // Next Q milestone in this region
+  next_nation_q_milestone: number | null; // Next Q milestone across all regions
+  fng_date: string | null; // FNG/first-event date (ISO string)
+  next_anniversary_date: string | null; // Date of next FNG anniversary (ISO string)
+  days_until_anniversary: number | null; // Days until the next FNG anniversary
 }
 
 /* USED ONLY FOR REGION KOTTER LISTING */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -155,6 +155,7 @@ export interface RegionAchievementPax {
   fng_date: string | null; // FNG/first-event date (ISO string)
   next_anniversary_date: string | null; // Date of next FNG anniversary (ISO string)
   days_until_anniversary: number | null; // Days until the next FNG anniversary
+  last_region_event_date: string | null; // Date of most recent event attended in this region (ISO string)
 }
 
 /* USED ONLY FOR REGION KOTTER LISTING */


### PR DESCRIPTION
### 👋 TL;DR

Adds an Achievements card to region pages showing upcoming PAX milestones (posts, Qs, FNG anniversaries within 14 days), and extends the unified search bar to support filtering inactive regions, AOs, and PAX.

### 🔎 Details

#### Achievements Card (`src/components/region/AchievementsCard.tsx`)

A new card on region pages surfaces approaching milestones for regional leadership to act on:

- **Post milestones** — PAX within 5 posts of a threshold (25, 50, 100, 200 … 1000), shown with longevity context from FNG date
- **Q milestones** — PAX within 3 Qs of a threshold, shown with Q rate
- **FNG anniversaries** — PAX whose F3 anniversary falls within the next 14 days (min 25 region posts to filter very new members)

**Scope toggle (Region / Nation)** adjusts which post/Q counts determine milestone proximity. Anniversaries are scope-independent.
**Type filter tabs (All / Posts / Qs / Anniversaries)** narrow the list.

The underlying data is computed in a single BigQuery CTE block added to `getPageData` in `src/lib/bq/regions.ts`. Milestone thresholds, anniversary dates, and urgency scores are all derived server-side. Anniversary math uses `DATE_ADD` (not `EXTRACT YEAR`) to handle Feb 29 FNG dates safely.

#### Search Enhancements

- **Include Inactive toggle** added to the search modal (`src/components/search-modal.tsx`) — passes `includeInactive=true` to the API when enabled
- **`/api/search` route** (`src/app/api/search/route.ts`) unified into a single `searchAll()` call backed by `src/lib/bq/search.ts`, replacing separate per-entity queries
- `searchRegionsByName` in `src/lib/bq/regions.ts` now accepts `includeInactive` and conditionally omits the `is_active = TRUE` filter

### ✅ How to Test

**Achievements Card**
1. Navigate to any region page that has active PAX.
2. Confirm the Achievements card appears below the existing cards.
3. Toggle the **Region / Nation** scope — post and Q counts should update; anniversary rows should remain unchanged.
4. Use the **All / Posts / Qs / Anniversaries** tabs to filter rows.
5. For a PAX within 5 posts of a threshold, confirm the row appears with longevity text (e.g., "4 posts away from 50 · PAX for 2 years, 3 months").
6. For a PAX with an anniversary ≤ 14 days away and ≥ 25 region posts, confirm the anniversary row appears with the correct date and days-until label.

**Search — Inactive Toggle**
1. Open the unified search bar (navbar).
2. Search for a name that belongs to an inactive region or AO.
3. Confirm the result does **not** appear by default.
4. Enable the **Include Inactive** toggle.
5. Re-run the same search and confirm the inactive result now appears.

### 🥜 GIF

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)