### PR TITLE
fix: Leaders filter controls to wrap on small screens

### DIFF
--- a/src/components/leaders.tsx
+++ b/src/components/leaders.tsx
@@ -81,9 +81,9 @@ export function LeadersCard({
   return (
     <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
       <CardHeader className="flex justify-between items-center px-6">
-        <div className="flex items-center justify-between w-full">
+        <div className="flex items-center justify-between w-full gap-3">
           <div className="font-semibold text-xl">Leaders</div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap justify-end">
             {page === "region" && (
               <Tabs
                 aria-label={`Select Leaders Scope`}


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

<!-- keep it simple, a sentence or two at most -->

Fixes a responsive layout issue in the Leaders card so filter controls wrap on narrow screens, matching the behavior in Achievements.

### 🔎 Details

<!--
This is the place to get in the weeds about what changed.
Consider linking out to project artifacts like:
- Jira issue(s)
- Slack post(s)
- Loom video(s)
- Figma design(s)
- etc.
-->

- Updated src/components/leaders.tsx header layout to better handle constrained widths.
- Added gap-3 to the header row container for consistent spacing.
- Updated the filter controls container to flex-wrap justify-end so:
     - Region/Nation and Posts/Qs/Q Rate can wrap to a second line when needed.
     - Desktop/wide layouts remain visually unchanged.
- No data logic, sorting, or filtering behavior changed; this is a UI/layout-only fix.

### ✅ How to Test

<!--
Document what a real testing looks like.
Think not only about code review,
but also about QA/UAT.
Given-When-Then acceptance criteria are great,
but even just a flat list of common test cases
in common language is better than nothing
-->

- Open a region stats page with the Leaders card visible.
- Resize viewport to a narrow/mobile width.
- Confirm filter controls wrap cleanly instead of overflowing/hugging one row.
- Toggle Region/Nation and Posts/Qs/Q Rate to confirm controls still work normally.
- Expand viewport back to desktop width and confirm single-row layout still looks correct.
- Compare against Achievements card behavior for consistency.

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

The issue I am observing:
<img width="421" height="801" alt="image" src="https://github.com/user-attachments/assets/588ecfb3-cafa-45de-b8bf-f68537a2757c" />

The fix i am proposing:
<img width="432" height="796" alt="image" src="https://github.com/user-attachments/assets/da0feb7c-1fb9-408b-b01c-d7398a075376" />


