### PR TITLE
Feat: AO Intelligence charts for region pages

### DIFF
--- a/src/app/stats/region/[regionId]/loader.ts
+++ b/src/app/stats/region/[regionId]/loader.ts
@@ -17,6 +17,9 @@ import {
   RegionKotterList,
   ChartData,
   RegionAchievementPax,
+  AOHeatmapData,
+  AOQDepthData,
+  AOPaxTrendData,
 } from "@/lib/types";
 import { getPageData } from "@/lib/bq/regions";
 
@@ -74,6 +77,9 @@ export async function loadRegionData(
       kotter: (mergedPlain.kotter ?? []) as RegionKotterList[],
       charts: (mergedPlain.charts ?? []) as ChartData[],
       achievements: (mergedPlain.achievements ?? []) as RegionAchievementPax[],
+      ao_heatmap: (mergedPlain.ao_heatmap ?? []) as AOHeatmapData[],
+      ao_q_depth: (mergedPlain.ao_q_depth ?? []) as AOQDepthData[],
+      ao_pax_trend: (mergedPlain.ao_pax_trend ?? []) as AOPaxTrendData[],
     };
 
     mergedSafe.events = (mergedSafe.events ?? []).map((e: EventData) => ({

--- a/src/app/stats/region/[regionId]/page.tsx
+++ b/src/app/stats/region/[regionId]/page.tsx
@@ -208,6 +208,9 @@ export default async function RegionDetailPage({
           region_events={regionData.events || []}
           region_charts={regionData.charts || []}
           region_achievements={regionData.achievements || []}
+          region_ao_heatmap={regionData.ao_heatmap || []}
+          region_ao_q_depth={regionData.ao_q_depth || []}
+          region_ao_pax_trend={regionData.ao_pax_trend || []}
           searchParams={{
             categoryIds,
             categoryMode,

--- a/src/components/region/AOChartsCard.tsx
+++ b/src/components/region/AOChartsCard.tsx
@@ -1,0 +1,572 @@
+"use client";
+
+import { AOHeatmapData, AOPaxTrendData, AOQDepthData } from "@/lib/types";
+import { Fragment, useState } from "react";
+import { Card, CardBody, CardFooter, CardHeader } from "@heroui/card";
+import { Divider } from "@heroui/divider";
+import {
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem,
+} from "@heroui/dropdown";
+import { Button } from "@heroui/button";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const LINE_COLORS = [
+  "#378ADD",
+  "#1D9E75",
+  "#EF9F27",
+  "#D85A30",
+  "#7F77DD",
+  "#E24B4A",
+];
+
+const tooltipStyle = {
+  contentStyle: {
+    backgroundColor: "hsl(var(--heroui-content1))",
+    border: "0.5px solid hsl(var(--heroui-default-200))",
+    borderRadius: "8px",
+    fontSize: "12px",
+  },
+  itemStyle: { color: "hsl(var(--heroui-foreground))" },
+  labelStyle: { color: "hsl(var(--heroui-default-500))", marginBottom: 2 },
+};
+
+// ─── Heatmap ────────────────────────────────────────────────────────────────
+
+export function HeatmapChart({ data }: { data: AOHeatmapData[] }) {
+  const aoNames = [...new Set(data.map((d) => d.ao_name))].sort();
+  const allValues = data.map((d) => d.avg_pax);
+  const maxVal = Math.max(...allValues, 1);
+
+  const cellMap = new Map<string, AOHeatmapData>();
+  data.forEach((d) => cellMap.set(`${d.ao_name}|${d.day_of_week}`, d));
+
+  const hasData = data.length > 0;
+
+  return (
+    <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
+      <CardHeader className="flex justify-between items-center px-6 lg:min-h-16">
+        <div className="font-semibold text-xl">Day-of-Week Attendance</div>
+      </CardHeader>
+      <Divider />
+      <CardBody className="px-6 overflow-x-auto">
+        {hasData ? (
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "80px repeat(6, 1fr)",
+              gap: 3,
+              minWidth: 320,
+            }}
+          >
+            {/* Header row */}
+            <div />
+            {DAYS.map((day) => (
+              <div
+                key={day}
+                className="text-center font-mono text-default-400"
+                style={{ fontSize: 10 }}
+              >
+                {day}
+              </div>
+            ))}
+            {/* Data rows */}
+            {aoNames.map((ao) => (
+              <Fragment key={ao}>
+                <div
+                  className="text-default-400 truncate pr-1"
+                  style={{ fontSize: 10, lineHeight: "26px" }}
+                  title={ao}
+                >
+                  {ao}
+                </div>
+                {DAYS.map((day) => {
+                  const cell = cellMap.get(`${ao}|${day}`);
+                  if (!cell) {
+                    return (
+                      <div
+                        key={`${ao}-${day}`}
+                        style={{
+                          height: 26,
+                          borderRadius: 4,
+                          background: "rgba(128,128,128,0.06)",
+                        }}
+                      />
+                    );
+                  }
+                  const alpha = 0.15 + (cell.avg_pax / maxVal) * 0.75;
+                  const textColor = alpha > 0.6 ? "#fff" : undefined;
+                  return (
+                    <div
+                      key={`${ao}-${day}`}
+                      title={`${ao} · ${day}: ${cell.avg_pax} avg PAX (${cell.workout_count} workouts)`}
+                      style={{
+                        height: 26,
+                        borderRadius: 4,
+                        background: `rgba(55,138,221,${alpha.toFixed(2)})`,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        fontSize: 10,
+                        fontFamily: "monospace",
+                        color: textColor,
+                        cursor: "default",
+                        transition: "transform 0.15s",
+                      }}
+                      onMouseEnter={(e) =>
+                        ((e.currentTarget as HTMLDivElement).style.transform =
+                          "scale(1.08)")
+                      }
+                      onMouseLeave={(e) =>
+                        ((e.currentTarget as HTMLDivElement).style.transform =
+                          "scale(1)")
+                      }
+                    >
+                      {cell.avg_pax}
+                    </div>
+                  );
+                })}
+              </Fragment>
+            ))}
+          </div>
+        ) : (
+          <div className="flex items-center justify-center text-xs text-default-400 py-10">
+            No workout data available for this period.
+          </div>
+        )}
+      </CardBody>
+      <Divider />
+      <CardFooter className="px-6 py-3">
+        <p className="text-xs text-default-400">
+          Average PAX per AO per day of week, trailing 90 days. Darker cells
+          mean higher average attendance.
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}
+
+// ─── Q Depth ────────────────────────────────────────────────────────────────
+
+function qDepthColor(pct: number) {
+  if (pct >= 70) return "#1D9E75";
+  if (pct >= 50) return "#EF9F27";
+  return "#E24B4A";
+}
+
+export function QDepthChart({ data }: { data: AOQDepthData[] }) {
+  const hasData = data.length > 0;
+  const chartHeight = Math.max(160, data.length * 28);
+
+  return (
+    <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
+      <CardHeader className="flex justify-between items-center px-6 lg:min-h-16">
+        <div className="font-semibold text-xl">Q Depth per AO</div>
+      </CardHeader>
+      <Divider />
+      <CardBody className="px-6">
+        {hasData ? (
+          <>
+            <ResponsiveContainer width="100%" height={chartHeight}>
+              <BarChart
+                data={data}
+                layout="vertical"
+                margin={{ top: 4, right: 20, left: 0, bottom: 4 }}
+              >
+                <CartesianGrid
+                  horizontal={false}
+                  stroke="rgba(128,128,128,0.08)"
+                />
+                <XAxis
+                  type="number"
+                  domain={[0, 100]}
+                  tickFormatter={(v) => `${v}%`}
+                  tick={{ fontSize: 10 }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="ao_name"
+                  width={80}
+                  tick={{ fontSize: 10 }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <ReferenceLine
+                  x={70}
+                  stroke="rgba(128,128,128,0.3)"
+                  strokeDasharray="3 3"
+                />
+                <Tooltip
+                  formatter={(_v, _n, props) => {
+                    const d = props.payload as AOQDepthData;
+                    return [
+                      `${d.q_depth_pct}% (${d.unique_qs} Qs / ${d.total_workouts} workouts)`,
+                      "Q Depth",
+                    ];
+                  }}
+                  {...tooltipStyle}
+                />
+                <Bar
+                  dataKey="q_depth_pct"
+                  barSize={12}
+                  radius={[0, 3, 3, 0]}
+                  fill="#1D9E75"
+                  shape={(props: unknown) => {
+                    const { x, y, width, height, value } = props as {
+                      x: number;
+                      y: number;
+                      width: number;
+                      height: number;
+                      value: number;
+                    };
+                    return (
+                      <rect
+                        x={x}
+                        y={y}
+                        width={width}
+                        height={height}
+                        rx={3}
+                        fill={qDepthColor(value)}
+                      />
+                    );
+                  }}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+            {/* Static legend */}
+            <div className="flex gap-4 mt-2 flex-wrap">
+              {[
+                { color: "#1D9E75", label: "Healthy (70%+)" },
+                { color: "#EF9F27", label: "Watch (50–69%)" },
+                { color: "#E24B4A", label: "At risk (<50%)" },
+              ].map(({ color, label }) => (
+                <div key={label} className="flex items-center gap-1">
+                  <div
+                    className="rounded-full"
+                    style={{
+                      width: 8,
+                      height: 8,
+                      background: color,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <span
+                    className="font-mono text-default-400"
+                    style={{ fontSize: 10 }}
+                  >
+                    {label}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div className="flex items-center justify-center text-xs text-default-400 py-10">
+            No Q data available for this period.
+          </div>
+        )}
+      </CardBody>
+      <Divider />
+      <CardFooter className="px-6 py-3">
+        <p className="text-xs text-default-400">
+          Ratio of unique Qs to total workouts per AO, trailing 90 days. Low
+          depth means a site runs on one or two people — a key-man risk.
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}
+
+// ─── Unique Qs per AO ───────────────────────────────────────────────────────
+
+export function UniqueQsPerAOChart({ data }: { data: AOQDepthData[] }) {
+  const hasData = data.length > 0;
+  const chartHeight = Math.max(160, data.length * 28);
+  const sorted = [...data].sort((a, b) => b.unique_qs - a.unique_qs);
+
+  return (
+    <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
+      <CardHeader className="flex justify-between items-center px-6 lg:min-h-16">
+        <div className="font-semibold text-xl">Unique Qs per AO</div>
+      </CardHeader>
+      <Divider />
+      <CardBody className="px-6">
+        {hasData ? (
+          <ResponsiveContainer width="100%" height={chartHeight}>
+            <BarChart
+              data={sorted}
+              layout="vertical"
+              margin={{ top: 4, right: 20, left: 0, bottom: 4 }}
+            >
+              <CartesianGrid
+                horizontal={false}
+                stroke="rgba(128,128,128,0.08)"
+              />
+              <XAxis
+                type="number"
+                allowDecimals={false}
+                tick={{ fontSize: 10 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                type="category"
+                dataKey="ao_name"
+                width={80}
+                tick={{ fontSize: 10 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip
+                formatter={(_v, _n, props) => {
+                  const d = props.payload as AOQDepthData;
+                  return [`${d.unique_qs} unique Qs`, "Unique Qs"];
+                }}
+                {...tooltipStyle}
+              />
+              <Bar
+                dataKey="unique_qs"
+                barSize={12}
+                radius={[0, 3, 3, 0]}
+                fill="#7C3AED"
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex items-center justify-center text-xs text-default-400 py-10">
+            No Q data available for this period.
+          </div>
+        )}
+      </CardBody>
+      <Divider />
+      <CardFooter className="px-6 py-3">
+        <p className="text-xs text-default-400">
+          Number of distinct leaders who have Q&apos;d at each AO, trailing 90
+          days. Shows how many people can run each site.
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}
+
+// ─── Avg PAX Trend ──────────────────────────────────────────────────────────
+
+export function AvgPaxTrendChart({ data }: { data: AOPaxTrendData[] }) {
+  const [selectedAO, setSelectedAO] = useState<string | null>(null);
+
+  const periods = [...new Set(data.map((d) => d.period))].sort((a, b) => {
+    return new Date(`1 ${a}`).getTime() - new Date(`1 ${b}`).getTime();
+  });
+
+  const allAONames = [...new Set(data.map((d) => d.ao_name))].filter((ao) => {
+    return data.filter((d) => d.ao_name === ao).length >= 3;
+  });
+
+  // Top 5 by mean avg_pax across all periods
+  const top5 = [...allAONames]
+    .map((ao) => {
+      const rows = data.filter((d) => d.ao_name === ao);
+      const mean = rows.reduce((s, d) => s + d.avg_pax, 0) / rows.length;
+      return { ao, mean };
+    })
+    .sort((a, b) => b.mean - a.mean)
+    .slice(0, 5)
+    .map((x) => x.ao);
+
+  // Region average per period (average of all AOs)
+  const regionAvgByPeriod = new Map<string, number>();
+  periods.forEach((p) => {
+    const rows = data.filter((d) => d.period === p);
+    if (rows.length) {
+      const avg =
+        Math.round(
+          (rows.reduce((s, d) => s + d.avg_pax, 0) / rows.length) * 10,
+        ) / 10;
+      regionAvgByPeriod.set(p, avg);
+    }
+  });
+
+  const activeAOs = selectedAO ? [selectedAO] : top5;
+
+  const pivoted = periods.map((period) => {
+    const row: Record<string, string | number> = { period };
+    if (selectedAO) {
+      const match = data.find(
+        (d) => d.ao_name === selectedAO && d.period === period,
+      );
+      if (match) row[selectedAO] = match.avg_pax;
+      const regionAvg = regionAvgByPeriod.get(period);
+      if (regionAvg !== undefined) row["Region Avg"] = regionAvg;
+    } else {
+      data
+        .filter((d) => d.period === period && top5.includes(d.ao_name))
+        .forEach((d) => {
+          row[d.ao_name] = d.avg_pax;
+        });
+    }
+    return row;
+  });
+
+  const hasData = allAONames.length > 0 && periods.length >= 2;
+
+  return (
+    <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
+      <CardHeader className="flex justify-between items-center px-6 lg:min-h-16">
+        <div className="font-semibold text-xl">Avg PAX Trend per AO</div>
+        {hasData && (
+          <Dropdown>
+            <DropdownTrigger>
+              <Button size="sm" variant="bordered" color="default">
+                {selectedAO ?? "Top 5 AOs"}
+              </Button>
+            </DropdownTrigger>
+            <DropdownMenu
+              aria-label="Select AO"
+              selectionMode="single"
+              selectedKeys={new Set([selectedAO ?? "__top5__"])}
+              onSelectionChange={(keys) => {
+                const k = Array.from(keys as Set<string>)[0];
+                setSelectedAO(k === "__top5__" ? null : k);
+              }}
+              items={[
+                { key: "__top5__", label: "Top 5 AOs" },
+                ...allAONames.map((ao) => ({ key: ao, label: ao })),
+              ]}
+            >
+              {(item) => (
+                <DropdownItem key={item.key}>{item.label}</DropdownItem>
+              )}
+            </DropdownMenu>
+          </Dropdown>
+        )}
+      </CardHeader>
+      <Divider />
+      <CardBody className="px-6">
+        {hasData ? (
+          <>
+            <ResponsiveContainer width="100%" height={250}>
+              <LineChart
+                data={pivoted}
+                margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke="rgba(128,128,128,0.08)"
+                />
+                <XAxis
+                  dataKey="period"
+                  tick={{ fontSize: 10 }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <YAxis
+                  tick={{ fontSize: 10 }}
+                  tickLine={false}
+                  axisLine={false}
+                  allowDecimals={false}
+                  label={{
+                    value: "Avg PAX",
+                    angle: -90,
+                    position: "insideLeft",
+                    style: {
+                      fontSize: 9,
+                      fill: "hsl(var(--heroui-default-400))",
+                    },
+                  }}
+                />
+                <Tooltip {...tooltipStyle} />
+                {selectedAO
+                  ? [
+                      <Line
+                        key={selectedAO}
+                        type="monotone"
+                        dataKey={selectedAO}
+                        stroke="#378ADD"
+                        strokeWidth={2}
+                        dot={{ r: 2.5 }}
+                        activeDot={{ r: 4 }}
+                        connectNulls
+                      />,
+                      <Line
+                        key="Region Avg"
+                        type="monotone"
+                        dataKey="Region Avg"
+                        stroke="rgba(128,128,128,0.5)"
+                        strokeWidth={1.5}
+                        strokeDasharray="4 4"
+                        dot={{ r: 2 }}
+                        activeDot={{ r: 3.5 }}
+                        connectNulls
+                      />,
+                    ]
+                  : activeAOs.map((ao, i) => (
+                      <Line
+                        key={ao}
+                        type="monotone"
+                        dataKey={ao}
+                        stroke={LINE_COLORS[i % LINE_COLORS.length]}
+                        strokeWidth={1.5}
+                        dot={{ r: 2.5 }}
+                        activeDot={{ r: 4 }}
+                        connectNulls
+                      />
+                    ))}
+              </LineChart>
+            </ResponsiveContainer>
+            {!selectedAO && (
+              <div className="flex gap-4 mt-2 flex-wrap">
+                {activeAOs.map((ao, i) => (
+                  <div key={ao} className="flex items-center gap-1">
+                    <div
+                      className="rounded-full"
+                      style={{
+                        width: 8,
+                        height: 8,
+                        background: LINE_COLORS[i % LINE_COLORS.length],
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span
+                      className="font-mono text-default-400 truncate"
+                      style={{ fontSize: 10 }}
+                    >
+                      {ao}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="flex items-center justify-center text-xs text-default-400 py-10">
+            Not enough history to show a trend yet.
+          </div>
+        )}
+      </CardBody>
+      <Divider />
+      <CardFooter className="px-6 py-3">
+        <p className="text-xs text-default-400">
+          {selectedAO
+            ? `${selectedAO} vs. the average of all active AOs, last 6 months.`
+            : "Top 5 AOs by average attendance, last 6 months. Select an AO from the dropdown to compare it against the region average."}
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/region/AchievementsCard.tsx
+++ b/src/components/region/AchievementsCard.tsx
@@ -343,7 +343,7 @@ export function AchievementsCard({
       </CardHeader>
       <Divider />
       <CardBody className="px-6">
-        <ScrollShadow className="h-[1105px]">
+        <ScrollShadow className="h-[500px]">
           <div className="space-y-1 text-sm">
             {visibleRows.length === 0 ? (
               <div className="italic text-default-500 text-sm py-2">

--- a/src/components/region/ChartsCard.tsx
+++ b/src/components/region/ChartsCard.tsx
@@ -1,76 +1,199 @@
 "use client";
 
-/**
- * Charting Card
- *
- * Displays high-level aggregate charts for a region
- * (workouts, AOs, PAX counts, Q counts, etc.).
- *
- * This component is purely presentational and assumes data has
- * already been validated and normalized upstream.
- */
-
-import { Card, CardBody, CardHeader } from "@heroui/card";
-import { Divider } from "@heroui/divider";
 import { ChartData } from "@/lib/types";
+import { Card, CardBody, CardFooter, CardHeader } from "@heroui/card";
+import { Divider } from "@heroui/divider";
 import {
+  Area,
+  AreaChart,
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
 
-type ChartCardProps = {
+type GrowthChartsCardProps = {
   charts: ChartData[];
 };
 
-const SimpleBarChart = (charts: ChartData[]) => {
-  return (
-    <ResponsiveContainer width="100%" aspect={1.618}>
-      <BarChart data={charts} margin={{ top: 5, right: 0, left: 0, bottom: 5 }}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
-        <YAxis yAxisId="left" orientation="left" stroke="#8884d8" />
-        <YAxis yAxisId="right" orientation="right" stroke="#82ca9d" />
-        <Tooltip />
-        <Legend />
-        <Bar
-          yAxisId="left"
-          dataKey="unique_pax_count"
-          fill="#8884d8"
-          radius={[10, 10, 0, 0]}
-        />
-        <Bar
-          yAxisId="right"
-          dataKey="unique_q_count"
-          fill="#82ca9d"
-          radius={[10, 10, 0, 0]}
-        />
-      </BarChart>
-    </ResponsiveContainer>
-  );
+function computeRollingAvg(data: ChartData[]): (number | null)[] {
+  return data.map((_, i) => {
+    const window = data.slice(Math.max(0, i - 3), i + 1);
+    const sum = window.reduce((acc, d) => acc + d.unique_pax_count, 0);
+    return Math.round((sum / window.length) * 10) / 10;
+  });
+}
+
+const tooltipStyle = {
+  contentStyle: {
+    backgroundColor: "hsl(var(--heroui-content1))",
+    border: "0.5px solid hsl(var(--heroui-default-200))",
+    borderRadius: "8px",
+    fontSize: "12px",
+  },
+  itemStyle: { color: "hsl(var(--heroui-foreground))" },
+  labelStyle: { color: "hsl(var(--heroui-default-500))", marginBottom: 2 },
 };
 
-export function ChartCard({ charts }: ChartCardProps) {
+function UniquePaxChart({ charts }: { charts: ChartData[] }) {
+  const rollingAvg = computeRollingAvg(charts);
+  const enriched = charts.map((d, i) => ({ ...d, rolling_avg: rollingAvg[i] }));
+  const hasData = charts.filter((d) => d.unique_pax_count > 0).length >= 2;
+
   return (
     <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
       <CardHeader className="flex justify-between items-center px-6 lg:min-h-16">
-        <div className="font-semibold text-xl">Region Charts</div>
+        <div className="font-semibold text-xl">Unique PAX Over Time</div>
       </CardHeader>
       <Divider />
       <CardBody className="px-6">
-        {charts.length > 0 ? (
-          SimpleBarChart(charts)
+        {hasData ? (
+          <ResponsiveContainer width="100%" height={140}>
+            <AreaChart
+              data={enriched}
+              margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
+            >
+              <defs>
+                <linearGradient id="paxFill" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#378ADD" stopOpacity={0.1} />
+                  <stop offset="95%" stopColor="#378ADD" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="rgba(128,128,128,0.08)"
+              />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 10 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                tick={{ fontSize: 10 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip
+                formatter={(value: number, name: string) => [
+                  value,
+                  name === "unique_pax_count" ? "Unique PAX" : "4-wk Avg",
+                ]}
+                {...tooltipStyle}
+              />
+              <Area
+                type="monotone"
+                dataKey="unique_pax_count"
+                stroke="#378ADD"
+                strokeWidth={2}
+                fill="url(#paxFill)"
+                dot={{ r: 2.5, fill: "#378ADD", strokeWidth: 0 }}
+                activeDot={{ r: 4 }}
+              />
+              <Area
+                type="monotone"
+                dataKey="rolling_avg"
+                stroke="#EF9F27"
+                strokeWidth={1.5}
+                strokeDasharray="4 3"
+                fill="none"
+                dot={false}
+                activeDot={false}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
         ) : (
-          <div className="text-center text-muted py-10">
-            No chart data available for this region.
+          <div
+            className="flex items-center justify-center text-xs text-default-400"
+            style={{ height: 140 }}
+          >
+            Not enough data to show a trend yet.
           </div>
         )}
       </CardBody>
+      <Divider />
+      <CardFooter className="px-6 py-3">
+        <p className="text-xs text-default-400">
+          Tracks distinct PAX per period with a 4-week rolling average to smooth
+          week-to-week noise and reveal the real growth trend.
+        </p>
+      </CardFooter>
     </Card>
+  );
+}
+
+function FngAcquisitionChart({ charts }: { charts: ChartData[] }) {
+  const hasData = charts.some((d) => d.fng_count > 0);
+
+  return (
+    <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
+      <CardHeader className="flex justify-between items-center px-6 lg:min-h-16">
+        <div className="font-semibold text-xl">FNG Acquisition</div>
+      </CardHeader>
+      <Divider />
+      <CardBody className="px-6">
+        {hasData ? (
+          <ResponsiveContainer width="100%" height={140}>
+            <BarChart
+              data={charts}
+              margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="rgba(128,128,128,0.08)"
+              />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 10 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                tick={{ fontSize: 10 }}
+                tickLine={false}
+                axisLine={false}
+                allowDecimals={false}
+              />
+              <Tooltip
+                formatter={(value: number) => [value, "FNGs"]}
+                {...tooltipStyle}
+              />
+              <Bar
+                dataKey="fng_count"
+                fill="#1D9E75"
+                radius={[3, 3, 0, 0]}
+                activeBar={{ fill: "rgba(29,158,117,0.85)" }}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div
+            className="flex items-center justify-center text-xs text-default-400"
+            style={{ height: 140 }}
+          >
+            No new members recorded in this period.
+          </div>
+        )}
+      </CardBody>
+      <Divider />
+      <CardFooter className="px-6 py-3">
+        <p className="text-xs text-default-400">
+          Each bar is one period of first-time attendees. Spikes reveal which
+          events or seasons drive new member growth.
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}
+
+export function ChartCard({ charts }: GrowthChartsCardProps) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 w-full">
+      <UniquePaxChart charts={charts} />
+      <FngAcquisitionChart charts={charts} />
+    </div>
   );
 }

--- a/src/components/region/PageWrapper.tsx
+++ b/src/components/region/PageWrapper.tsx
@@ -19,6 +19,8 @@ import {
   RegionInfo,
   ChartData,
   RegionAchievementPax,
+  AOHeatmapData,
+  AOQDepthData,
 } from "@/lib/types";
 import { SummaryCard } from "./SummaryCard";
 import { LeadersCard } from "../leaders";
@@ -28,6 +30,7 @@ import { EventsCard } from "../events";
 import { Filter } from "../pageFilter";
 import { useMemo } from "react";
 import { ChartCard } from "./ChartsCard";
+import { HeatmapChart, QDepthChart, UniqueQsPerAOChart } from "./AOChartsCard";
 import { AchievementsCard } from "./AchievementsCard";
 
 type RegionalPageWrapperProps = {
@@ -40,6 +43,9 @@ type RegionalPageWrapperProps = {
   region_events: EventData[];
   region_charts: ChartData[];
   region_achievements: RegionAchievementPax[];
+  region_ao_heatmap: AOHeatmapData[];
+  region_ao_q_depth: AOQDepthData[];
+  region_ao_pax_trend: unknown[];
   searchParams: {
     categoryIds?: string | string[];
     categoryMode?: string;
@@ -104,6 +110,8 @@ export function RegionalPageWrapper({
   region_events,
   region_charts,
   region_achievements,
+  region_ao_heatmap,
+  region_ao_q_depth,
   searchParams,
 }: RegionalPageWrapperProps) {
   // Memoized query-string passed to events + filter components.
@@ -140,26 +148,32 @@ export function RegionalPageWrapper({
         />
       </div>
       {/* Charting */}
-      <div className="grid grid-cols-1 gap-6 w-full max-w-6xl hidden">
+      <div className="grid grid-cols-1 gap-6 w-full max-w-6xl">
         <ChartCard charts={region_charts || []} />
       </div>
-      {/* Upcoming achievements */}
+      {/* Unique Qs + Q Depth */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 w-full max-w-6xl">
+        <UniqueQsPerAOChart data={region_ao_q_depth || []} />
+        <QDepthChart data={region_ao_q_depth || []} />
+      </div>
+      {/* Heatmap + Achievements */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 w-full max-w-6xl">
+        <HeatmapChart data={region_ao_heatmap || []} />
         <AchievementsCard
           achievements={region_achievements || []}
           filters={eventsFiltersQuery}
         />
-        {/* Kotters + upcoming events */}
-        <div className="grid grid-cols-1 gap-6 w-full max-w-6xl">
-          <KotterCard
-            kotters={region_kotter || []}
-            filters={eventsFiltersQuery}
-          />
-          <UpcomingEventsCard
-            events={region_upcoming || []}
-            filters={eventsFiltersQuery}
-          />
-        </div>
+      </div>
+      {/* Kotters + upcoming events */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 w-full max-w-6xl">
+        <KotterCard
+          kotters={region_kotter || []}
+          filters={eventsFiltersQuery}
+        />
+        <UpcomingEventsCard
+          events={region_upcoming || []}
+          filters={eventsFiltersQuery}
+        />
       </div>
       {/* Event list */}
       <div className="grid grid-cols-1 gap-6 w-full max-w-6xl">

--- a/src/lib/bq/regions.ts
+++ b/src/lib/bq/regions.ts
@@ -8,6 +8,9 @@ import {
   RegionKotterList,
   ChartData,
   RegionAchievementPax,
+  AOHeatmapData,
+  AOQDepthData,
+  AOPaxTrendData,
 } from "@/lib/types";
 
 /**
@@ -344,17 +347,11 @@ export async function getPageData(
   leaders: Leaders[] | null;
   upcoming: EventUpcoming[] | null;
   kotter: RegionKotterList[] | null;
-  charts:
-    | {
-        date: string;
-        pax_count: number;
-        fng_count: number;
-        q_count: number;
-        unique_pax_count: number;
-        unique_q_count: number;
-      }[]
-    | null;
+  charts: ChartData[] | null;
   achievements: RegionAchievementPax[] | null;
+  ao_heatmap: AOHeatmapData[] | null;
+  ao_q_depth: AOQDepthData[] | null;
+  ao_pax_trend: AOPaxTrendData[] | null;
 }> {
   // Build WHERE clause from common filters (region-scoped).
   const whereSql = buildEventsWhereSql(regionId, opts);
@@ -721,6 +718,7 @@ export async function getPageData(
           period_event_agg AS (
             SELECT
               DATE_TRUNC(event_date, ${truncUnit}) AS period,
+              COUNT(*) AS event_count,
               SUM(pax_count) AS pax_count,
               SUM(fng_count) AS fng_count,
               SUM((SELECT COUNTIF(a.q_ind = 1) FROM UNNEST(attendance) a)) AS q_count
@@ -738,6 +736,7 @@ export async function getPageData(
           period_agg AS (
             SELECT
               ea.period,
+              ea.event_count,
               ea.pax_count,
               ea.fng_count,
               ea.q_count,
@@ -760,6 +759,7 @@ export async function getPageData(
           ARRAY_AGG(
             STRUCT(
               ds.date AS date,
+              COALESCE(pa.event_count, 0) AS event_count,
               COALESCE(pa.pax_count, 0) AS pax_count,
               COALESCE(pa.fng_count, 0) AS fng_count,
               COALESCE(pa.q_count, 0) AS q_count,
@@ -770,7 +770,83 @@ export async function getPageData(
           )
         FROM date_spine ds
         LEFT JOIN period_agg pa ON pa.period = ds.date
-      ) AS charts;
+      ) AS charts,
+
+      -- AO heatmap: avg PAX per AO per day-of-week, trailing 90 days (fixed window)
+      (
+        WITH
+          ao_90day AS (
+            SELECT ao_name, event_date, pax_count
+            FROM \`f3data.paxVault.pv_events\`
+            WHERE region_org_id = ${regionId}
+              AND event_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+              AND first_f_ind = 1
+          ),
+          ao_heatmap_agg AS (
+            SELECT
+              ao_name,
+              FORMAT_DATE('%a', event_date) AS day_of_week,
+              ROUND(AVG(pax_count), 1) AS avg_pax,
+              COUNT(*) AS workout_count
+            FROM ao_90day
+            GROUP BY ao_name, day_of_week
+          )
+        SELECT ARRAY_AGG(STRUCT(ao_name, day_of_week, avg_pax, workout_count))
+        FROM ao_heatmap_agg
+      ) AS aoHeatmap,
+
+      -- AO Q depth: unique Qs vs total workouts per AO, trailing 90 days (fixed window)
+      (
+        WITH
+          ao_90day AS (
+            SELECT ao_name, event_date, attendance
+            FROM \`f3data.paxVault.pv_events\`
+            WHERE region_org_id = ${regionId}
+              AND event_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+              AND first_f_ind = 1
+          ),
+          ao_event_counts AS (
+            SELECT ao_name, COUNT(*) AS total_workouts
+            FROM ao_90day
+            GROUP BY ao_name
+          ),
+          ao_q_counts AS (
+            SELECT e.ao_name, COUNT(DISTINCT IF(a.q_ind = 1, a.user_id, NULL)) AS unique_qs
+            FROM ao_90day e, UNNEST(e.attendance) a
+            GROUP BY e.ao_name
+          ),
+          ao_q_depth_agg AS (
+            SELECT
+              ec.ao_name,
+              ec.total_workouts,
+              COALESCE(qc.unique_qs, 0) AS unique_qs,
+              ROUND(SAFE_DIVIDE(COALESCE(qc.unique_qs, 0), ec.total_workouts) * 100, 1) AS q_depth_pct
+            FROM ao_event_counts ec
+            LEFT JOIN ao_q_counts qc USING (ao_name)
+          )
+        SELECT ARRAY_AGG(STRUCT(ao_name, unique_qs, total_workouts, q_depth_pct) ORDER BY q_depth_pct DESC)
+        FROM ao_q_depth_agg
+      ) AS aoQDepth,
+
+      -- AO avg PAX trend: avg PAX per AO per month, trailing 6 months (fixed window)
+      (
+        WITH
+          ao_pax_trend_agg AS (
+            SELECT
+              ao_name,
+              FORMAT_DATE('%b %Y', DATE_TRUNC(event_date, MONTH)) AS period,
+              DATE_TRUNC(event_date, MONTH) AS period_date,
+              ROUND(AVG(pax_count), 1) AS avg_pax,
+              COUNT(*) AS workout_count
+            FROM \`f3data.paxVault.pv_events\`
+            WHERE region_org_id = ${regionId}
+              AND event_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH)
+              AND first_f_ind = 1
+            GROUP BY ao_name, period, period_date
+          )
+        SELECT ARRAY_AGG(STRUCT(ao_name, period, avg_pax, workout_count) ORDER BY period_date, ao_name)
+        FROM ao_pax_trend_agg
+      ) AS aoPaxTrend;
     `;
 
   const results = await queryBigQuery<{
@@ -782,6 +858,9 @@ export async function getPageData(
     kotter: RegionKotterList[];
     charts: ChartData[];
     achievements: RegionAchievementPax[];
+    aoHeatmap: AOHeatmapData[];
+    aoQDepth: AOQDepthData[];
+    aoPaxTrend: AOPaxTrendData[];
   }>(query, userIdentifier, `fetch region data for region ${regionId}`);
 
   return {
@@ -793,5 +872,8 @@ export async function getPageData(
     kotter: results?.[0]?.kotter || null,
     charts: results?.[0]?.charts || null,
     achievements: results?.[0]?.achievements || null,
+    ao_heatmap: results?.[0]?.aoHeatmap || null,
+    ao_q_depth: results?.[0]?.aoQDepth || null,
+    ao_pax_trend: results?.[0]?.aoPaxTrend || null,
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -98,11 +98,33 @@ export interface ChartData {
   q_count: number; // Number of Qs (leaders) for the chart data point
   unique_pax_count: number; // Number of unique participants (pax) for the chart data point
   unique_q_count: number; // Number of unique Qs (leaders) for the chart data point
+  event_count?: number; // Number of distinct workouts posted in the period
 }
 
 /* =========================================================== */
 /*                REGION-SPECIFIC TYPES BELOW                  */
 /* =========================================================== */
+
+export interface AOHeatmapData {
+  ao_name: string;
+  day_of_week: string;
+  avg_pax: number;
+  workout_count: number;
+}
+
+export interface AOQDepthData {
+  ao_name: string;
+  unique_qs: number;
+  total_workouts: number;
+  q_depth_pct: number;
+}
+
+export interface AOPaxTrendData {
+  ao_name: string;
+  period: string;
+  avg_pax: number;
+  workout_count: number;
+}
 
 // REGION DATA MODEL
 export interface RegionData {
@@ -114,6 +136,9 @@ export interface RegionData {
   kotter: RegionKotterList[] | null; // List of Kotter events in the region
   charts: ChartData[] | null; // List of chart data points for the region
   achievements: RegionAchievementPax[] | null; // PAX approaching milestones or with upcoming anniversaries
+  ao_heatmap: AOHeatmapData[] | null;
+  ao_q_depth: AOQDepthData[] | null;
+  ao_pax_trend: AOPaxTrendData[] | null;
 }
 
 /* USED ONLY FOR REGION INFO */


### PR DESCRIPTION
### 👋 TL;DR

Adds four new data visualizations to the region stats page — all backed by new BigQuery sub-queries — giving F3 leaders a richer picture of how each AO is performing.

### 🔎 Details

**New charts added to region pages**

| Chart | Data source | Window |
|---|---|---|
| **Unique PAX Over Time** | `charts` (existing) | Date-filter aware |
| **FNG Acquisition** | `charts` (existing) | Date-filter aware |
| **Unique Qs per AO** | `ao_q_depth.unique_qs` | Trailing 90 days |
| **Q Depth per AO** | `ao_q_depth.q_depth_pct` | Trailing 90 days |
| **Day-of-Week Attendance** heatmap | `ao_heatmap` | Trailing 90 days |

**New BigQuery sub-queries** in `regions.ts`:
- `ao_heatmap` — avg PAX per AO per day-of-week (Mon–Sat), trailing 90 days, first-F events only
- `ao_q_depth` — unique Qs ÷ total workouts per AO, trailing 90 days; used by both the Q Depth % chart and the Unique Qs count chart
- `ao_pax_trend` — avg PAX per AO per month for 6 months (data fetched, reserved for a future iteration)

**Page layout (region):**
```
[Unique PAX Over Time]  [FNG Acquisition]
[Unique Qs per AO]      [Q Depth per AO]
[Day-of-Week Heatmap]   [Achievements]
[Kotters]               [Upcoming Events]
[Event List]
```

**New types** added to `types.ts`: `AOHeatmapData`, `AOQDepthData`, `AOPaxTrendData`

### ✅ How to Test

- Navigate to any region stats page (`/stats/region/<id>`)
- Confirm six chart cards render: Unique PAX Over Time, FNG Acquisition, Unique Qs per AO, Q Depth per AO, Day-of-Week Attendance heatmap, Achievements
- Hover cells on the heatmap — tooltip should show `AO · Day: X avg PAX (Y workouts)`
- Hover bars on Q Depth — tooltip should show `X% (Y Qs / Z workouts)`
- Verify Q Depth bars color correctly: green ≥70%, amber 50–69%, red <50%
- Verify "No data" empty states on a region with no workout history
- Apply a date filter — Unique PAX and FNG charts should update; AO charts (fixed 90-day window) should stay unchanged

### 🥜 GIF

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)