### PR TITLE
fix(attendance): exclude fartsack no-shows from rosters and counts

### DIFF
--- a/src/components/events.test.ts
+++ b/src/components/events.test.ts
@@ -12,6 +12,9 @@ function att(overrides: Partial<EventAttendance>): EventAttendance {
     coq_ind: false,
     avatar_url: null,
     isBot: false,
+    attended: true,
+    ghost: false,
+    fartsack: false,
     ...overrides,
   };
 }

--- a/src/lib/bq/aos.ts
+++ b/src/lib/bq/aos.ts
@@ -182,7 +182,7 @@ export async function getEvents(
       third_f_ind,
       types,
       tags,
-      attendance
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
     FROM pv_events
     WHERE ao_org_id = ${aoId}
     ORDER BY event_date DESC, event_id DESC
@@ -229,7 +229,11 @@ export async function getPageData(
           third_f_ind,
           types,
           tags,
-          attendance
+          -- Strip fartsack (no-show) PAX once here so attendance_flat (and thus
+          -- active_pax/unique_pax, the leaders' post counts) and the events list
+          -- all exclude no-shows. 'fartsack IS NOT TRUE' keeps legacy rows
+          -- (flag NULL/FALSE) + real attendees.
+          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
         FROM pv_events
         ${whereSql}
       ),

--- a/src/lib/bq/areas.ts
+++ b/src/lib/bq/areas.ts
@@ -178,7 +178,10 @@ export async function getPageData(
           ao_org_id,
           region_org_id,
           region_name,
-          attendance
+          -- Strip fartsack (no-show) PAX once here so attendance_flat and every
+          -- downstream count (unique_pax, active_pax) exclude no-shows.
+          -- 'fartsack IS NOT TRUE' keeps legacy rows (flag NULL/FALSE) + attendees.
+          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
         FROM pv_events
         WHERE area_org_id = ${areaId}
           ${dateFilterSql}

--- a/src/lib/bq/events.ts
+++ b/src/lib/bq/events.ts
@@ -29,7 +29,10 @@ export async function getEventById(
       third_f_ind,
       types,
       tags,
-      attendance
+      -- Exclude fartsack (signed-up no-show) PAX from the roster/count. See
+      -- attendance flags note in pax.ts. 'fartsack IS NOT TRUE' keeps legacy
+      -- rows (flag NULL/FALSE) and real attendees, drops only no-shows.
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
     FROM pv_events
     WHERE event_id = ${eventInstanceId}
     LIMIT 1;

--- a/src/lib/bq/pax.ts
+++ b/src/lib/bq/pax.ts
@@ -33,12 +33,15 @@ function buildEventsWhereSql(paxId: number, opts?: StatsFilters): string {
   );
 
   const whereClauses: string[] = [];
-  // Attendance filter: only include events where the given PAX appears in the attendance array for that event.
+  // Attendance filter: only include events where the given PAX actually attended.
+  // `a.fartsack IS NOT TRUE` excludes events the PAX signed up for but no-showed
+  // (and keeps legacy rows where the flag is NULL/FALSE).
   whereClauses.push(
     `EXISTS (
       SELECT 1
       FROM UNNEST(attendance) a
       WHERE a.user_id = ${paxId}
+        AND a.fartsack IS NOT TRUE
     )`,
   );
 
@@ -216,12 +219,13 @@ export async function getEvents(
       third_f_ind,
       types,
       tags,
-      attendance
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
     FROM pv_events
     WHERE EXISTS (
       SELECT 1
       FROM UNNEST(attendance) a
       WHERE a.user_id = ${paxId}
+        AND a.fartsack IS NOT TRUE
     )
     ORDER BY event_date DESC, event_id DESC
     ${limitSql};
@@ -355,7 +359,11 @@ export async function getPageData(
           third_f_ind,
           types,
           tags,
-          attendance
+          -- Strip fartsack (no-show) PAX once here so every downstream CTE that
+          -- unnests e.attendance (attendance_flat, co_attendance, ao_events) and
+          -- the final events array all exclude no-shows. 'fartsack IS NOT TRUE'
+          -- preserves legacy rows (flag NULL/FALSE) and real attendees.
+          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
         FROM pv_events
         ${whereSql}
       ),

--- a/src/lib/bq/regions.ts
+++ b/src/lib/bq/regions.ts
@@ -255,7 +255,7 @@ export async function getEvents(
       third_f_ind,
       types,
       tags,
-      attendance
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
     FROM pv_events
     ${whereSql}
     ORDER BY event_date DESC, event_id DESC
@@ -378,7 +378,10 @@ export async function getPageData(
           third_f_ind,
           types,
           tags,
-          attendance
+          -- Strip fartsack (no-show) PAX once here so attendance_flat, the events
+          -- list, the summary counts, and the charts all exclude no-shows.
+          -- 'fartsack IS NOT TRUE' keeps legacy rows (flag NULL/FALSE) + attendees.
+          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
         FROM pv_events
         ${whereSql}
       ),
@@ -427,7 +430,10 @@ export async function getPageData(
         JOIN UNNEST(e.attendance) a
         JOIN leader_ids li
           ON li.user_id = a.user_id
-        WHERE a.user_id IS NOT NULL${eventsFilterAndSql}
+        -- Exclude fartsack (no-show) rows so posts/all_posts count real
+        -- attendance only; the q_ind-based counts are unaffected (a no-show Q
+        -- reads q_ind = 0).
+        WHERE a.user_id IS NOT NULL AND a.fartsack IS NOT TRUE${eventsFilterAndSql}
         GROUP BY a.user_id
       ),
 
@@ -458,6 +464,9 @@ export async function getPageData(
         FROM pv_events e
         JOIN UNNEST(e.attendance) a ON TRUE
         JOIN achievement_pax_base pb ON pb.user_id = a.user_id
+        -- Exclude fartsack (no-show) rows so post milestones reflect real
+        -- attendance; q_ind-based Q milestones are unaffected.
+        WHERE a.fartsack IS NOT TRUE
         GROUP BY a.user_id
       ),
 

--- a/src/lib/bq/sectors.ts
+++ b/src/lib/bq/sectors.ts
@@ -176,7 +176,10 @@ export async function getPageData(
           ao_org_id,
           area_org_id,
           area_name,
-          attendance
+          -- Strip fartsack (no-show) PAX once here so attendance_flat and every
+          -- downstream count (unique_pax, active_pax) exclude no-shows.
+          -- 'fartsack IS NOT TRUE' keeps legacy rows (flag NULL/FALSE) + attendees.
+          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
         FROM pv_events
         WHERE sector_org_id = ${sectorId}
           ${dateFilterSql}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,6 +43,9 @@ export interface EventAttendance {
   coq_ind: boolean; // Indicates if the user was a co-Q (co-leader) for the event
   avatar_url: string | null; // Optional URL to the user's avatar image
   isBot: boolean; // Indicates if the user is a bot
+  attended: boolean | null; // Has an actual (is_planned=FALSE) record — physically there
+  ghost: boolean | null; // Attended unannounced (actual record, no planned record)
+  fartsack: boolean | null; // Signed up but no-showed — filtered out at the SQL source (bq/*.ts)
 }
 
 /* USED FOR UPCOMING EVENTS */


### PR DESCRIPTION
### 👋 TL;DR

`pv_events.attendance` gained `attended`/`ghost`/`fartsack` flags and now includes no-show ("fartsack") PAX in the array. This strips fartsacks at the SQL source so rosters and counts stop overcounting; no-shows are hidden everywhere and ghosts render as ordinary attendees.

### 🔎 Details

The `attendance` `ARRAY<STRUCT>` gained three nullable `BOOL` fields — `attended`, `ghost`, `fartsack` — and the array now also contains **fartsack** PAX (signed up, no-showed). Any consumer treating the raw array as the attendee list overcounts and renders no-shows as if present.

Fartsacks are removed **at the SQL source**, so every downstream consumer (page loaders, `/api/.../events` routes, the single-event route, and all components) receives fartsack-free arrays. No component logic changed.

- **Returned arrays** wrapped in `ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE)` across `events.ts`, `pax.ts`, `regions.ts`, `aos.ts`, `sectors.ts`, `areas.ts`.
- **Participation aggregations** in `regions.ts` (`leaders_rollup` posts + achievement post counts) and the PAX **event-membership filters** gained `a.fartsack IS NOT TRUE`. Q-based counts (`q_ind = 1`) were left alone — a no-show Q reads `q_ind = 0`, so they're already correct.
- **Type**: added `attended` / `ghost` / `fartsack` (`boolean | null`) to `EventAttendance` and the test factory.

Canonical predicate is `fartsack IS NOT TRUE` (true for both `FALSE` and `NULL`), **not** `attended = TRUE` — so legacy events (new flags `NULL`/`FALSE`) keep their real attendees instead of dropping to zero.

**Product decisions:** fartsacks are hidden everywhere (roster + counts); ghosts get no badge.

### ✅ How to Test

Automated (all green on this branch):
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 109/109 pass
- `npm run build` — clean, all routes compile

Manual / QA:
- Open an event with a known no-show: the PAX roster and the "N attendee(s)" label exclude the fartsack; the Q list is unchanged; ghosts appear as normal attendees.
- Spot-check a PAX page, region, and AO page for sane attendee/post counts.
- Data sanity (validated against live BigQuery): PAX 318 appears in 414 attendance rows = 412 attended + 2 fartsacks → the new code reports **412** (old code overcounts at 414).

Post-deploy note: production caches stats pages for up to 1 hour (`STATS_REVALIDATE_SECONDS`), so counts settle after the revalidate window.

### 🥜 GIF

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)