### PR TITLE
feat(stats): ghost/fartsack metrics + Fart Sack King

### DIFF
--- a/src/components/ao/PageWrapper.tsx
+++ b/src/components/ao/PageWrapper.tsx
@@ -107,7 +107,7 @@ export function AOPageWrapper({
       )}
       {/* Summary + leaders */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 w-full max-w-6xl">
-        <SummaryCard summary={ao_summary!} />
+        <SummaryCard summary={ao_summary!} filters={eventsFiltersQuery} />
         <LeadersCard
           leaders={
             ao_leaders

--- a/src/components/ao/SummaryCard.tsx
+++ b/src/components/ao/SummaryCard.tsx
@@ -12,14 +12,16 @@
 
 import { Card, CardBody, CardHeader } from "@heroui/card";
 import { Divider } from "@heroui/divider";
+import { Link } from "@heroui/link";
 import { AOSummary } from "@/lib/types";
 import { renderStat } from "@/lib/utils";
 
 type SummaryCardProps = {
   summary: AOSummary;
+  filters?: string;
 };
 
-export function SummaryCard({ summary }: SummaryCardProps) {
+export function SummaryCard({ summary, filters }: SummaryCardProps) {
   return (
     <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
       <CardHeader className="flex justify-between items-center px-6 lg:min-h-16">
@@ -47,6 +49,25 @@ export function SummaryCard({ summary }: SummaryCardProps) {
         <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
           <span className="text-primary">FNGs:</span>
           <span>{renderStat(summary.fng_count, undefined, "FNGs")}</span>
+        </div>
+        <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
+          <span className="text-primary">Fart Sack King:</span>
+          <span>
+            {summary.fartsack_king_count && summary.fartsack_king_user_id ? (
+              <>
+                <Link
+                  className="text-sm"
+                  color="secondary"
+                  href={`/stats/pax/${summary.fartsack_king_user_id}${filters ? `?${filters}` : ""}`}
+                >
+                  {summary.fartsack_king_f3_name || "Unknown PAX"}
+                </Link>
+                {` (${renderStat(summary.fartsack_king_count)})`}
+              </>
+            ) : (
+              "No PAX"
+            )}
+          </span>
         </div>
         <div className="flex justify-between py-1 pb-2">
           <span className="text-primary">Average PAX:</span>

--- a/src/components/area/SummaryCard.tsx
+++ b/src/components/area/SummaryCard.tsx
@@ -9,6 +9,7 @@
 
 import { Card, CardBody, CardHeader } from "@heroui/card";
 import { Divider } from "@heroui/divider";
+import { Link } from "@heroui/link";
 import { AreaSummary } from "@/lib/types";
 import { renderStat } from "@/lib/utils";
 import { HelpHint } from "@/components/HelpHint";
@@ -55,6 +56,25 @@ export function AreaSummaryCard({ summary }: AreaSummaryCardProps) {
         <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
           <span className="text-primary">FNGs:</span>
           <span>{renderStat(summary.fng_count, undefined, "FNGs")}</span>
+        </div>
+        <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
+          <span className="text-primary">Fart Sack King:</span>
+          <span>
+            {summary.fartsack_king_count && summary.fartsack_king_user_id ? (
+              <>
+                <Link
+                  className="text-sm"
+                  color="secondary"
+                  href={`/stats/pax/${summary.fartsack_king_user_id}`}
+                >
+                  {summary.fartsack_king_f3_name || "Unknown PAX"}
+                </Link>
+                {` (${renderStat(summary.fartsack_king_count)})`}
+              </>
+            ) : (
+              "No PAX"
+            )}
+          </span>
         </div>
         <div className="flex justify-between py-1 pb-2">
           <span className="text-primary">Average PAX:</span>

--- a/src/components/pax/SummaryCard.tsx
+++ b/src/components/pax/SummaryCard.tsx
@@ -43,6 +43,26 @@ export function SummaryCard({
             </span>
           </div>
           <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
+            <span className="text-primary">Ghost Events:</span>
+            <span>
+              {summary?.event_count === 0 ? (
+                <span className="text-default-500 italic">No Event Data</span>
+              ) : (
+                <>{formatNumber(summary.ghost_count)}</>
+              )}
+            </span>
+          </div>
+          <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
+            <span className="text-primary">Fart Sacked:</span>
+            <span>
+              {summary?.event_count === 0 ? (
+                <span className="text-default-500 italic">No Event Data</span>
+              ) : (
+                <>{formatNumber(summary.fartsack_count)}</>
+              )}
+            </span>
+          </div>
+          <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
             <span className="text-primary">FNG Date:</span>
             <span>
               {summary?.event_count === 0 ? (

--- a/src/components/region/PageWrapper.tsx
+++ b/src/components/region/PageWrapper.tsx
@@ -125,7 +125,7 @@ export function RegionalPageWrapper({
       )}
       {/* Summary + leaders */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 w-full max-w-6xl">
-        <SummaryCard summary={region_summary!} />
+        <SummaryCard summary={region_summary!} filters={eventsFiltersQuery} />
         <LeadersCard
           leaders={
             region_leaders

--- a/src/components/region/SummaryCard.tsx
+++ b/src/components/region/SummaryCard.tsx
@@ -12,15 +12,17 @@
 
 import { Card, CardBody, CardHeader } from "@heroui/card";
 import { Divider } from "@heroui/divider";
+import { Link } from "@heroui/link";
 import { RegionSummary } from "@/lib/types";
 import { renderStat } from "@/lib/utils";
 import { HelpHint } from "@/components/HelpHint";
 
 type SummaryCardProps = {
   summary: RegionSummary;
+  filters?: string;
 };
 
-export function SummaryCard({ summary }: SummaryCardProps) {
+export function SummaryCard({ summary, filters }: SummaryCardProps) {
   return (
     <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
       <CardHeader className="flex justify-between items-center px-6 lg:min-h-16">
@@ -55,6 +57,25 @@ export function SummaryCard({ summary }: SummaryCardProps) {
         <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10 text-sm">
           <span className="text-primary">FNGs:</span>
           <span>{renderStat(summary.fng_count, undefined, "FNGs")}</span>
+        </div>
+        <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10 text-sm">
+          <span className="text-primary">Fart Sack King:</span>
+          <span>
+            {summary.fartsack_king_count && summary.fartsack_king_user_id ? (
+              <>
+                <Link
+                  className="text-sm"
+                  color="secondary"
+                  href={`/stats/pax/${summary.fartsack_king_user_id}${filters ? `?${filters}` : ""}`}
+                >
+                  {summary.fartsack_king_f3_name || "Unknown PAX"}
+                </Link>
+                {` (${renderStat(summary.fartsack_king_count)})`}
+              </>
+            ) : (
+              "No PAX"
+            )}
+          </span>
         </div>
         <div className="flex justify-between py-1 pb-2 text-sm">
           <span className="text-primary">Average PAX:</span>

--- a/src/components/sector/SummaryCard.tsx
+++ b/src/components/sector/SummaryCard.tsx
@@ -9,6 +9,7 @@
 
 import { Card, CardBody, CardHeader } from "@heroui/card";
 import { Divider } from "@heroui/divider";
+import { Link } from "@heroui/link";
 import { SectorSummary } from "@/lib/types";
 import { renderStat } from "@/lib/utils";
 import { HelpHint } from "@/components/HelpHint";
@@ -55,6 +56,25 @@ export function SectorSummaryCard({ summary }: SectorSummaryCardProps) {
         <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
           <span className="text-primary">FNGs:</span>
           <span>{renderStat(summary.fng_count, undefined, "FNGs")}</span>
+        </div>
+        <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
+          <span className="text-primary">Fart Sack King:</span>
+          <span>
+            {summary.fartsack_king_count && summary.fartsack_king_user_id ? (
+              <>
+                <Link
+                  className="text-sm"
+                  color="secondary"
+                  href={`/stats/pax/${summary.fartsack_king_user_id}`}
+                >
+                  {summary.fartsack_king_f3_name || "Unknown PAX"}
+                </Link>
+                {` (${renderStat(summary.fartsack_king_count)})`}
+              </>
+            ) : (
+              "No PAX"
+            )}
+          </span>
         </div>
         <div className="flex justify-between py-1 pb-2">
           <span className="text-primary">Average PAX:</span>

--- a/src/lib/bq/aos.ts
+++ b/src/lib/bq/aos.ts
@@ -250,8 +250,23 @@ export async function getPageData(
         FROM events e
         LEFT JOIN UNNEST(e.attendance) a
         WHERE a.user_id IS NOT NULL
+      ),
+
+      -- Fart Sack King: PAX with the most no-shows at this AO. Fartsacks are
+      -- stripped from the events CTE above, so count them from the raw
+      -- pv_events table (same filters via whereSql). Empty when nobody has any.
+      fartsack_king AS (
+        SELECT
+          a.user_id,
+          ANY_VALUE(a.f3_name) AS f3_name,
+          COUNT(*) AS fartsack_count
+        FROM pv_events e, UNNEST(e.attendance) a
+        ${whereSql ? `${whereSql}\n          AND a.fartsack IS TRUE` : "WHERE a.fartsack IS TRUE"}
+        GROUP BY a.user_id
+        ORDER BY fartsack_count DESC
+        LIMIT 1
       )
-        
+
     SELECT
       -- AO info as a STRUCT
       (
@@ -313,7 +328,10 @@ export async function getPageData(
           am.unique_pax,
           am.unique_qs,
           em.fng_count,
-          em.pax_count_average
+          em.pax_count_average,
+          (SELECT user_id FROM fartsack_king) AS fartsack_king_user_id,
+          (SELECT f3_name FROM fartsack_king) AS fartsack_king_f3_name,
+          (SELECT fartsack_count FROM fartsack_king) AS fartsack_king_count
         FROM event_metrics em
         CROSS JOIN attendance_metrics am
       ) AS summary,

--- a/src/lib/bq/areas.ts
+++ b/src/lib/bq/areas.ts
@@ -198,6 +198,24 @@ export async function getPageData(
         WHERE a.user_id IS NOT NULL
       ),
 
+      -- Fart Sack King: PAX with the most no-shows in this area. Fartsacks are
+      -- stripped from the events CTE above, so count them from the raw
+      -- pv_events table (same area + date filters). Empty when nobody has any.
+      fartsack_king AS (
+        SELECT
+          a.user_id,
+          ANY_VALUE(a.f3_name) AS f3_name,
+          COUNT(*) AS fartsack_count
+        FROM pv_events e
+        JOIN UNNEST(e.attendance) a
+        WHERE e.area_org_id = ${areaId}
+          AND a.fartsack IS TRUE
+          ${dateFilterSql}
+        GROUP BY a.user_id
+        ORDER BY fartsack_count DESC
+        LIMIT 1
+      ),
+
       -- Region-level event aggregates
       region_event_stats AS (
         SELECT
@@ -306,7 +324,10 @@ export async function getPageData(
           am.unique_pax,
           am.unique_qs,
           em.fng_count,
-          em.pax_count_average
+          em.pax_count_average,
+          (SELECT user_id FROM fartsack_king) AS fartsack_king_user_id,
+          (SELECT f3_name FROM fartsack_king) AS fartsack_king_f3_name,
+          (SELECT fartsack_count FROM fartsack_king) AS fartsack_king_count
         FROM area_event_metrics em
         CROSS JOIN area_attendance_metrics am
       ) AS summary,

--- a/src/lib/bq/pax.ts
+++ b/src/lib/bq/pax.ts
@@ -12,7 +12,15 @@ import { StatsFilters, toFiniteNumbers } from "@/lib/filters";
  * - tagIds/typeIds use EXISTS / NOT EXISTS against the nested arrays.
  * - categories maps 1/2/3 to first_f_ind/second_f_ind/third_f_ind and combines with OR.
  */
-function buildEventsWhereSql(paxId: number, opts?: StatsFilters): string {
+function buildEventsWhereSql(
+  paxId: number,
+  opts?: StatsFilters,
+  // Predicate applied to the PAX's attendance row inside the EXISTS gate.
+  // Defaults to "physically posted" (no-shows excluded). Pass
+  // `a.fartsack IS TRUE` to instead select events the PAX signed up for but
+  // no-showed — those rows are otherwise stripped at the events CTE.
+  attendancePredicate: string = "a.fartsack IS NOT TRUE",
+): string {
   const rangeDates = buildRangeDates(opts?.range);
   const startDate = opts?.startDate ?? rangeDates.startDate;
   const endDate = opts?.endDate ?? rangeDates.endDate;
@@ -41,7 +49,7 @@ function buildEventsWhereSql(paxId: number, opts?: StatsFilters): string {
       SELECT 1
       FROM UNNEST(attendance) a
       WHERE a.user_id = ${paxId}
-        AND a.fartsack IS NOT TRUE
+        AND ${attendancePredicate}
     )`,
   );
 
@@ -316,6 +324,10 @@ export async function getPageData(
 }> {
   // Build WHERE clause from common filters.
   const whereSql = buildEventsWhereSql(paxId, opts);
+  // Fartsacks (signed up, no-showed) are stripped from the events CTE, so count
+  // them straight from pv_events using the same filters but the inverse
+  // attendance gate.
+  const fartsackWhereSql = buildEventsWhereSql(paxId, opts, "a.fartsack IS TRUE");
 
   const query = `-- PAX PAGE LOAD
     WITH
@@ -380,7 +392,8 @@ export async function getPageData(
           a.user_id,
           a.f3_name,
           a.q_ind,
-          a.coq_ind
+          a.coq_ind,
+          a.ghost
         FROM events e
         JOIN UNNEST(e.attendance) a
       ),
@@ -480,8 +493,17 @@ export async function getPageData(
       metrics AS (
         SELECT
           COUNT(*) AS event_count,
-          SUM(CASE WHEN q_ind = 1 THEN 1 ELSE 0 END) AS q_count
+          SUM(CASE WHEN q_ind = 1 THEN 1 ELSE 0 END) AS q_count,
+          -- Ghost rows (attended unannounced) survive the fartsack filter, so
+          -- they're already in self_attendance.
+          SUM(CASE WHEN ghost IS TRUE THEN 1 ELSE 0 END) AS ghost_count
         FROM self_attendance
+      ),
+      -- Fartsacks are stripped upstream; count them from the raw events table.
+      fartsack_metrics AS (
+        SELECT COUNT(*) AS fartsack_count
+        FROM pv_events
+        ${fartsackWhereSql}
       ),
 
       -- -----------------------
@@ -491,6 +513,8 @@ export async function getPageData(
         SELECT
           m.event_count,
           m.q_count,
+          m.ghost_count,
+          fs.fartsack_count,
           pi.start_date_override,
           eb.first_event_date,
           ebao.first_event_ao_id,
@@ -518,6 +542,7 @@ export async function getPageData(
             DATE_DIFF(CURRENT_DATE(), eb.first_event_date, DAY))
             * 100 AS effective_percentage
         FROM metrics m
+        CROSS JOIN fartsack_metrics fs
         CROSS JOIN event_bounds eb
         LEFT JOIN event_bounds_ao ebao
           ON TRUE
@@ -591,6 +616,8 @@ export async function getPageData(
         SELECT AS STRUCT
           event_count,
           q_count,
+          ghost_count,
+          fartsack_count,
           IFNULL(CAST(start_date_override AS STRING), CAST(first_event_date AS STRING)) AS fng_date,
           CAST(first_event_date AS STRING) AS first_event_date,
           first_event_ao_id,

--- a/src/lib/bq/pax.ts
+++ b/src/lib/bq/pax.ts
@@ -327,7 +327,11 @@ export async function getPageData(
   // Fartsacks (signed up, no-showed) are stripped from the events CTE, so count
   // them straight from pv_events using the same filters but the inverse
   // attendance gate.
-  const fartsackWhereSql = buildEventsWhereSql(paxId, opts, "a.fartsack IS TRUE");
+  const fartsackWhereSql = buildEventsWhereSql(
+    paxId,
+    opts,
+    "a.fartsack IS TRUE",
+  );
 
   const query = `-- PAX PAGE LOAD
     WITH

--- a/src/lib/bq/regions.ts
+++ b/src/lib/bq/regions.ts
@@ -399,6 +399,23 @@ export async function getPageData(
         WHERE a.user_id IS NOT NULL
       ),
 
+      -- Fart Sack King: PAX with the most no-shows in this region. Fartsacks are
+      -- stripped from the events CTE above, so count them from the raw
+      -- pv_events table (same region + filters). Empty when nobody has any.
+      fartsack_king AS (
+        SELECT
+          a.user_id,
+          ANY_VALUE(a.f3_name) AS f3_name,
+          COUNT(*) AS fartsack_count
+        FROM pv_events e
+        JOIN UNNEST(e.attendance) a
+        WHERE e.region_org_id = ${regionId}
+          AND a.fartsack IS TRUE${eventsFilterAndSql}
+        GROUP BY a.user_id
+        ORDER BY fartsack_count DESC
+        LIMIT 1
+      ),
+
       -- Leaders in-region (also used as the "who to include" list)
       leaders_region_dim AS (
         SELECT
@@ -587,7 +604,10 @@ export async function getPageData(
           am.unique_pax,
           am.unique_qs,
           em.fng_count,
-          em.pax_count_average
+          em.pax_count_average,
+          (SELECT user_id FROM fartsack_king) AS fartsack_king_user_id,
+          (SELECT f3_name FROM fartsack_king) AS fartsack_king_f3_name,
+          (SELECT fartsack_count FROM fartsack_king) AS fartsack_king_count
         FROM event_metrics em
         CROSS JOIN attendance_metrics am
       ) AS summary,

--- a/src/lib/bq/sectors.ts
+++ b/src/lib/bq/sectors.ts
@@ -196,6 +196,24 @@ export async function getPageData(
         WHERE a.user_id IS NOT NULL
       ),
 
+      -- Fart Sack King: PAX with the most no-shows in this sector. Fartsacks are
+      -- stripped from the events CTE above, so count them from the raw
+      -- pv_events table (same sector + date filters). Empty when nobody has any.
+      fartsack_king AS (
+        SELECT
+          a.user_id,
+          ANY_VALUE(a.f3_name) AS f3_name,
+          COUNT(*) AS fartsack_count
+        FROM pv_events e
+        JOIN UNNEST(e.attendance) a
+        WHERE e.sector_org_id = ${sectorId}
+          AND a.fartsack IS TRUE
+          ${dateFilterSql}
+        GROUP BY a.user_id
+        ORDER BY fartsack_count DESC
+        LIMIT 1
+      ),
+
       -- Area-level event aggregates
       area_event_stats AS (
         SELECT
@@ -304,7 +322,10 @@ export async function getPageData(
           am.unique_pax,
           am.unique_qs,
           em.fng_count,
-          em.pax_count_average
+          em.pax_count_average,
+          (SELECT user_id FROM fartsack_king) AS fartsack_king_user_id,
+          (SELECT f3_name FROM fartsack_king) AS fartsack_king_f3_name,
+          (SELECT fartsack_count FROM fartsack_king) AS fartsack_king_count
         FROM sector_event_metrics em
         CROSS JOIN sector_attendance_metrics am
       ) AS summary,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -141,6 +141,9 @@ export interface RegionSummary {
   unique_qs: number; // Number of unique Qs (leaders) who have led events in the region
   fng_count: number; // Total number of first-time participants (FNGs) in the region
   pax_count_average: number; // Average number of participants (pax) per event in the region
+  fartsack_king_user_id: number | null; // PAX with the most fartsacks (no-shows) in the region; null when none
+  fartsack_king_f3_name: string | null; // F3 name of the Fart Sack King; null when none
+  fartsack_king_count: number | null; // Number of fartsacks for the Fart Sack King; null when none
 }
 
 /* USED FOR REGION UPCOMING ACHIEVEMENTS */
@@ -215,6 +218,8 @@ export interface PAXInfo {
 export interface PaxSummary {
   event_count: number; // Total number of events held in the region
   q_count: number; // Total number of Qs (leaders) across all events
+  ghost_count: number; // Number of events the PAX attended unannounced (ghost)
+  fartsack_count: number; // Number of events the PAX signed up for but no-showed (fartsack)
   fng_date: string | null; // Optional override for the user's start date, can be null
   first_event_date: string | null; // Date of the first event in the region
   first_event_ao_id: number | null; // ID of the first event in the region
@@ -279,6 +284,9 @@ export interface AreaSummary {
   unique_qs: number;
   fng_count: number;
   pax_count_average: number;
+  fartsack_king_user_id: number | null; // PAX with the most fartsacks (no-shows) in the area; null when none
+  fartsack_king_f3_name: string | null; // F3 name of the Fart Sack King; null when none
+  fartsack_king_count: number | null; // Number of fartsacks for the Fart Sack King; null when none
 }
 
 /* USED FOR AREA REGION BREAKDOWN */
@@ -325,6 +333,9 @@ export interface SectorSummary {
   unique_qs: number;
   fng_count: number;
   pax_count_average: number;
+  fartsack_king_user_id: number | null; // PAX with the most fartsacks (no-shows) in the sector; null when none
+  fartsack_king_f3_name: string | null; // F3 name of the Fart Sack King; null when none
+  fartsack_king_count: number | null; // Number of fartsacks for the Fart Sack King; null when none
 }
 
 /* USED FOR SECTOR AREA BREAKDOWN */
@@ -374,4 +385,7 @@ export interface AOSummary {
   unique_qs: number; // Number of unique Qs (leaders) who have led events in the AO
   fng_count: number; // Total number of first-time participants (FNGs) in the AO
   pax_count_average: number; // Average number of participants (pax) per event in the AO
+  fartsack_king_user_id: number | null; // PAX with the most fartsacks (no-shows) at the AO; null when none
+  fartsack_king_f3_name: string | null; // F3 name of the Fart Sack King; null when none
+  fartsack_king_count: number | null; // Number of fartsacks for the Fart Sack King; null when none
 }


### PR DESCRIPTION
### 👋 TL;DR

Adds ghost/fartsack counts to the PAX page and a new **Fart Sack King** (PAX with the most no-shows) to the AO, Region, Area, and Sector pages.

### 🔎 Details

Builds on the recently-finished ghost/fartsack attendance logic.

**PAX page** ([`pax/SummaryCard.tsx`](../blob/feat/fartsack-metrics/src/components/pax/SummaryCard.tsx)) — two new rows under **Total Qs**:
- **Ghost Events** — events the PAX attended unannounced. Ghosts survive the fartsack filter, so counted inline in the existing `metrics` CTE.
- **Fart Sacked** — events the PAX signed up for but no-showed. These are stripped at the `events` CTE, so counted from raw `pv_events` via a new `fartsack_metrics` CTE that honors the active date/AO/region/tag/type filters.

**AO / Region / Area / Sector pages** — new **Fart Sack King** row under **FNGs**: the PAX with the most fartsacks at that scope, linking to their PAX page, with the count in parens. Shows **No PAX** when there are none. Each uses a `fartsack_king` CTE reading raw `pv_events` scoped to that level + the page's filters (since the `events` CTE strips no-shows).

Touches: `lib/bq/{pax,aos,regions,areas,sectors}.ts`, `lib/types.ts`, and the five `SummaryCard` components (+ AO/Region `PageWrapper` to thread the filter query into the king link).

Notes:
- Counts are filter-aware on PAX/AO/Region (Area/Sector pages run unfiltered today, pre-existing).
- Ties are broken arbitrarily (`LIMIT 1`).
- `tsc --noEmit` and `eslint` both pass; **not yet validated against live BigQuery** — hence this PR to staging.

### ✅ How to Test

1. Deploy this branch to staging.
2. **PAX page** (`/stats/pax/[id]`): confirm **Ghost Events** and **Fart Sacked** appear under Total Qs with sane numbers; spot-check a PAX with known ghost/no-show records. Apply a date/AO filter and confirm Fart Sacked changes accordingly.
3. **AO / Region / Area / Sector pages**: confirm **Fart Sack King** appears under FNGs, shows the right PAX + count, and links to their PAX page.
4. Verify a scope with **zero** fartsacks renders **No PAX**.
5. Confirm numbers reconcile with the underlying attendance data in BigQuery.

### 🥜 GIF

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
