### PR TITLE
feat(events): show Fart Sackers chips + label roster sections

### DIFF
--- a/src/components/EventDetailsContent.tsx
+++ b/src/components/EventDetailsContent.tsx
@@ -35,6 +35,11 @@ const getQList = (event: EventData) =>
 
 const getPaxList = (event: EventData) => sortAttendance(event.attendance);
 
+// No-shows (signed up but didn't post). Separate array, kept out of the
+// attendance roster and counts.
+const getFartsackList = (event: EventData) =>
+  sortAttendance(event.fartsacks ?? []);
+
 export function EventDetailsHeader({
   event,
   filters,
@@ -180,9 +185,9 @@ export function EventDetailsBody({
               variant="bordered"
               color="default"
               size="sm"
-              // Ghosts (attended unannounced) keep the default border but get
-              // danger-colored text to flag them.
-              classNames={{ content: pax.ghost ? "text-danger" : "" }}
+              // Ghosts (attended unannounced) get muted text — they posted,
+              // just off-plan.
+              classNames={{ content: pax.ghost ? "text-default-400" : "" }}
             >
               {pax.f3_name ?? pax.user_id.toString()}
             </Chip>
@@ -198,6 +203,37 @@ export function EventDetailsBody({
     </div>
   );
 
+  // Fart Sacks: signed up but no-showed. Rendered as its own labeled, danger
+  // section after the PAX chips; null when there are none.
+  const fartsackChips =
+    getFartsackList(event).length > 0 ? (
+      <div className="mt-3">
+        <div className="text-xs tracking-wide text-danger mb-2">
+          Fart Sackers
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {getFartsackList(event).map((pax, i) => (
+            <Link
+              key={`fartsack-${event.event_instance_id}-${i}`}
+              href={`/stats/pax/${pax.user_id}${filters ? `?${filters}` : ""}`}
+              className="text-default-100"
+            >
+              <Chip
+                avatar={
+                  <Avatar showFallback src={pax.avatar_url || undefined} />
+                }
+                variant="bordered"
+                color="danger"
+                size="sm"
+              >
+                {pax.f3_name ?? pax.user_id.toString()}
+              </Chip>
+            </Link>
+          ))}
+        </div>
+      </div>
+    ) : null;
+
   return (
     <div className="space-y-6">
       {hasEventImages ? (
@@ -206,8 +242,8 @@ export function EventDetailsBody({
           <div className="flex-1 min-w-0 rounded-lg border border-default-200 dark:border-default-300 bg-background/60 dark:bg-default-100/50 p-4">
             <div className="space-y-5">
               <div>
-                <div className="text-xs uppercase tracking-wide text-default-500 mb-2">
-                  Q
+                <div className="text-xs tracking-wide text-default-500 mb-2">
+                  Qs
                 </div>
                 {qChips}
               </div>
@@ -220,6 +256,7 @@ export function EventDetailsBody({
                   {paxCountLabel}
                 </div>
                 {paxChips}
+                {fartsackChips}
               </div>
             </div>
           </div>
@@ -283,8 +320,8 @@ export function EventDetailsBody({
         <section className="rounded-lg border border-default-200 dark:border-default-300 bg-background/60 dark:bg-default-100/50 p-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <div className="text-xs uppercase tracking-wide text-default-500 mb-2">
-                Q
+              <div className="text-xs tracking-wide text-default-500 mb-2">
+                Qs
               </div>
               {qChips}
             </div>
@@ -297,6 +334,7 @@ export function EventDetailsBody({
                 {paxCountLabel}
               </div>
               {paxChips}
+              {fartsackChips}
             </div>
           </div>
         </section>

--- a/src/components/events.tsx
+++ b/src/components/events.tsx
@@ -228,6 +228,11 @@ export function EventsCard({
 
   const getPaxList = (event: EventData) => sortAttendance(event.attendance);
 
+  // No-shows (signed up but didn't post). Lives in its own array so it never
+  // mixes with the attendance roster or its counts.
+  const getFartsackList = (event: EventData) =>
+    sortAttendance(event.fartsacks ?? []);
+
   // Client-side search across event, AO, region, PAX, and Q names, plus the
   // optional "As Q" gate that hides events this PAX did not Q (issue #115).
   const filteredEvents = eventsData.filter((ev) => {
@@ -368,6 +373,7 @@ export function EventsCard({
                 const pax_list = getPaxList(event);
                 const q_list = getQList(event);
                 const coq_list = getcoQList(event);
+                const fartsack_list = getFartsackList(event);
 
                 return (
                   <div key={event.event_instance_id || index}>
@@ -456,7 +462,8 @@ export function EventsCard({
                           </div>
                         </div>
 
-                        <div className="flex gap-2 pb-2">
+                        <div className="flex flex-col gap-1 pb-2">
+                          <span className="text-xs text-default-500">Qs</span>
                           <div className="flex flex-wrap gap-1">
                             {q_list.length === 0 ? (
                               <Chip
@@ -516,7 +523,8 @@ export function EventsCard({
                               : null}
                           </div>
                         </div>
-                        <div className="flex justify-between pb-2">
+                        <div className="flex flex-col gap-1 pb-2">
+                          <span className="text-xs text-default-500">PAX</span>
                           <div className="flex flex-wrap gap-1 w-full">
                             {pax_list.length === 0 ? (
                               <span className="italic text-default-500">
@@ -563,12 +571,11 @@ export function EventsCard({
                                         variant="bordered"
                                         color="default"
                                         size="sm"
-                                        // Ghosts (attended unannounced) keep the
-                                        // default border but get danger-colored
-                                        // text to flag them more subtly.
+                                        // Ghosts (attended unannounced) get muted
+                                        // text — they posted, just off-plan.
                                         classNames={{
                                           content: pax.ghost
-                                            ? "text-danger"
+                                            ? "text-default-400"
                                             : "",
                                         }}
                                       >
@@ -591,6 +598,38 @@ export function EventsCard({
                             )}
                           </div>
                         </div>
+                        {/* Fart Sacks: signed up but no-showed. Separate labeled
+                            row, kept out of the attendee chips and counts. */}
+                        {fartsack_list.length > 0 && (
+                          <div className="flex flex-col gap-1 pb-2">
+                            <span className="text-xs text-danger">
+                              Fart Sackers
+                            </span>
+                            <div className="flex flex-wrap gap-1 w-full">
+                              {fartsack_list.map((pax, i) => (
+                                <Link
+                                  key={`fartsack-${event.event_instance_id}-${i}`}
+                                  href={`/stats/pax/${pax.user_id}${filters ? `?${filters}` : ""}`}
+                                  className="text-default-100"
+                                >
+                                  <Chip
+                                    avatar={
+                                      <Avatar
+                                        showFallback
+                                        src={pax.avatar_url || undefined}
+                                      />
+                                    }
+                                    variant="bordered"
+                                    color="danger"
+                                    size="sm"
+                                  >
+                                    {pax.f3_name ?? pax.user_id.toString()}
+                                  </Chip>
+                                </Link>
+                              ))}
+                            </div>
+                          </div>
+                        )}
                       </CardBody>
                     </Card>
                   </div>

--- a/src/lib/bq/aos.ts
+++ b/src/lib/bq/aos.ts
@@ -183,7 +183,8 @@ export async function getEvents(
       third_f_ind,
       types,
       tags,
-      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance,
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS TRUE) AS fartsacks
     FROM pv_events
     WHERE ao_org_id = ${aoId}
     ORDER BY event_date DESC, event_id DESC
@@ -234,7 +235,10 @@ export async function getPageData(
           -- active_pax/unique_pax, the leaders' post counts) and the events list
           -- all exclude no-shows. 'fartsack IS NOT TRUE' keeps legacy rows
           -- (flag NULL/FALSE) + real attendees.
-          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
+          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance,
+          -- Display-only roster of the no-shows for the UI chips; not consumed
+          -- by any aggregate CTE.
+          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS TRUE) AS fartsacks
         FROM pv_events
         ${whereSql}
       ),
@@ -311,8 +315,8 @@ export async function getPageData(
               third_f_ind,
               types,
               tags,
-              attendance
-              -- omit attendance unless the UI truly needs it here
+              attendance,
+              fartsacks
             )
             ORDER BY event_date DESC, event_id DESC
             LIMIT 100

--- a/src/lib/bq/events.ts
+++ b/src/lib/bq/events.ts
@@ -32,7 +32,9 @@ export async function getEventById(
       -- Exclude fartsack (signed-up no-show) PAX from the roster/count. See
       -- attendance flags note in pax.ts. 'fartsack IS NOT TRUE' keeps legacy
       -- rows (flag NULL/FALSE) and real attendees, drops only no-shows.
-      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance,
+      -- Display-only roster of the no-shows for the UI chips.
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS TRUE) AS fartsacks
     FROM pv_events
     WHERE event_id = ${eventInstanceId}
     LIMIT 1;

--- a/src/lib/bq/pax.ts
+++ b/src/lib/bq/pax.ts
@@ -228,7 +228,8 @@ export async function getEvents(
       third_f_ind,
       types,
       tags,
-      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance,
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS TRUE) AS fartsacks
     FROM pv_events
     WHERE EXISTS (
       SELECT 1
@@ -380,7 +381,10 @@ export async function getPageData(
           -- unnests e.attendance (attendance_flat, co_attendance, ao_events) and
           -- the final events array all exclude no-shows. 'fartsack IS NOT TRUE'
           -- preserves legacy rows (flag NULL/FALSE) and real attendees.
-          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
+          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance,
+          -- Display-only roster of the no-shows; never consumed by any aggregate
+          -- CTE, only surfaced on the final events struct for the UI chips.
+          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS TRUE) AS fartsacks
         FROM pv_events
         ${whereSql}
       ),
@@ -663,7 +667,8 @@ export async function getPageData(
                 e.third_f_ind,
                 e.types,
                 e.tags,
-                e.attendance)
+                e.attendance,
+                e.fartsacks)
               ORDER BY e.event_date DESC, e.event_id DESC)
           FROM events e
           LIMIT 100

--- a/src/lib/bq/regions.ts
+++ b/src/lib/bq/regions.ts
@@ -256,7 +256,8 @@ export async function getEvents(
       third_f_ind,
       types,
       tags,
-      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance,
+      ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS TRUE) AS fartsacks
     FROM pv_events
     ${whereSql}
     ORDER BY event_date DESC, event_id DESC
@@ -382,7 +383,10 @@ export async function getPageData(
           -- Strip fartsack (no-show) PAX once here so attendance_flat, the events
           -- list, the summary counts, and the charts all exclude no-shows.
           -- 'fartsack IS NOT TRUE' keeps legacy rows (flag NULL/FALSE) + attendees.
-          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance
+          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS NOT TRUE) AS attendance,
+          -- Display-only roster of the no-shows for the UI chips; not consumed
+          -- by any aggregate CTE.
+          ARRAY(SELECT a FROM UNNEST(attendance) a WHERE a.fartsack IS TRUE) AS fartsacks
         FROM pv_events
         ${whereSql}
       ),
@@ -580,8 +584,8 @@ export async function getPageData(
               third_f_ind,
               types,
               tags,
-              attendance
-              -- omit attendance unless the UI truly needs it here
+              attendance,
+              fartsacks
             )
             ORDER BY event_date DESC, event_id DESC
             LIMIT 100)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,6 +31,7 @@ export interface EventData {
     | null; // List of all types/categories associated with the event
   tags: { id: number; name: string; description: string }[] | null; // List of all tags associated with the event
   attendance: EventAttendance[]; // List of attendance records for the event
+  fartsacks?: EventAttendance[]; // Signed up but no-showed; display-only, excluded from attendance and all counts
 }
 
 /* USED FOR EVENT ATTENDANCE RECORDS */


### PR DESCRIPTION
### 👋 TL;DR

Surfaces no-show (fartsack) PAX as a distinct **Fart Sackers** chip group in event rosters, labels the roster sections **Qs / PAX / Fart Sackers**, and mutes ghost attendees — all without disturbing any existing attendance metric.

### 🔎 Details

Until now fartsacks (signed up, no-showed) were stripped at the SQL layer and never reached the UI — deliberately, because ~15 downstream CTEs read the `attendance` array and including no-shows there would re-inflate Unique PAX Met / Bestie / leaderboards (the #123 regression).

This adds them as **display-only**, with zero blast radius:

- **Data layer** — a parallel `fartsacks` array (`WHERE a.fartsack IS TRUE`) added next to the existing stripped `attendance` in every event-producing query (`getPageData` + `getEvents` for pax/ao/region, and `getEventById`), plus an optional `fartsacks?: EventAttendance[]` on `EventData`. No aggregate CTE reads it. `areas.ts`/`sectors.ts` return no event list, so untouched. `pax_count` and the "N PAX"/"N attendee(s)" labels are unchanged.
- **UI** — in the recent events list, the View Details modal, and the standalone event page (the latter two share `EventDetailsContent`):
  - New **Fart Sackers** group: danger border + text, in its own labeled section after the attendees.
  - Roster sections now labeled **Qs**, **PAX**, **Fart Sackers** (non-bold).
  - **Ghosts** changed from danger-red to **muted** text (they posted, just off-plan) — flips the visual hierarchy so no-shows stand out, not ghosts.

Follows the merged #124/#125 fartsack work.

`tsc`, `eslint`, and `prettier --check` all pass. **Not yet validated against live BigQuery.**

### ✅ How to Test

1. Deploy to staging.
2. Open a PAX / AO / Region page with an event that has no-shows:
   - Recent events list shows **Qs / PAX / Fart Sackers** section labels; no-shows appear as danger-bordered chips in the Fart Sackers group; ghosts (if any) show muted names.
3. Click **View Details** → same layout in the modal.
4. Open `/stats/events/[id]` → same on the standalone page.
5. Confirm attendee counts (`pax_count`, "N PAX", "N attendee(s)") are unchanged — fartsacks must NOT be counted there.
6. Confirm summary metrics (Unique PAX Met, Bestie, leaderboards, Fart Sack/Ghost King) are unchanged vs. before.
7. Reconcile chip membership for one event against BigQuery (`fartsack = TRUE`).

### 🥜 GIF

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
