### PR TITLE
feat(stats): hide Fart Sack King / Ghost King from public view

### DIFF
--- a/src/components/EventDetailsContent.tsx
+++ b/src/components/EventDetailsContent.tsx
@@ -37,8 +37,9 @@ const getPaxList = (event: EventData) => sortAttendance(event.attendance);
 
 // No-shows (signed up but didn't post). Separate array, kept out of the
 // attendance roster and counts.
-const getFartsackList = (event: EventData) =>
-  sortAttendance(event.fartsacks ?? []);
+// Hidden from public view for now — kept for easy restore.
+// const getFartsackList = (event: EventData) =>
+//   sortAttendance(event.fartsacks ?? []);
 
 export function EventDetailsHeader({
   event,
@@ -180,14 +181,13 @@ export function EventDetailsBody({
             href={`/stats/pax/${pax.user_id}${filters ? `?${filters}` : ""}`}
             className="text-default-100"
           >
+            {/* Ghost styling hidden from public view for now — ghosts render as
+                normal chips. (pax.ghost flag still computed upstream.) */}
             <Chip
               avatar={<Avatar showFallback src={pax.avatar_url || undefined} />}
               variant="bordered"
               color="default"
               size="sm"
-              // Ghosts (attended unannounced) get muted text — they posted,
-              // just off-plan.
-              classNames={{ content: pax.ghost ? "text-default-400" : "" }}
             >
               {pax.f3_name ?? pax.user_id.toString()}
             </Chip>
@@ -203,8 +203,12 @@ export function EventDetailsBody({
     </div>
   );
 
-  // Fart Sacks: signed up but no-showed. Rendered as its own labeled, danger
-  // section after the PAX chips; null when there are none.
+  // Fart Sacks: signed up but no-showed. Hidden from public view for now — the
+  // fartsack roster (event.fartsacks) is still computed upstream; fartsackChips
+  // is null so the {fartsackChips} render slots below show nothing. The original
+  // render is kept below for easy restore.
+  const fartsackChips = null;
+  /*
   const fartsackChips =
     getFartsackList(event).length > 0 ? (
       <div className="mt-3">
@@ -233,6 +237,7 @@ export function EventDetailsBody({
         </div>
       </div>
     ) : null;
+  */
 
   return (
     <div className="space-y-6">

--- a/src/components/ao/SummaryCard.tsx
+++ b/src/components/ao/SummaryCard.tsx
@@ -14,15 +14,20 @@ import { Card, CardBody, CardHeader } from "@heroui/card";
 import { Divider } from "@heroui/divider";
 import { AOSummary } from "@/lib/types";
 import { renderStat } from "@/lib/utils";
-import { KingCell } from "@/components/KingCell";
-import { HelpHint } from "@/components/HelpHint";
+// Fart Sack King / Ghost King hidden from public view for now — imports kept
+// commented so the rows below can be restored without re-wiring.
+// import { KingCell } from "@/components/KingCell";
+// import { HelpHint } from "@/components/HelpHint";
 
 type SummaryCardProps = {
   summary: AOSummary;
   filters?: string;
 };
 
-export function SummaryCard({ summary, filters }: SummaryCardProps) {
+// `filters` stays in the props type (callers still pass it) but is unused while
+// the Fart Sack King / Ghost King rows are hidden; re-add it to the destructure
+// when restoring those rows.
+export function SummaryCard({ summary }: SummaryCardProps) {
   return (
     <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
       <CardHeader className="flex justify-between items-center px-6 lg:min-h-16">
@@ -51,6 +56,8 @@ export function SummaryCard({ summary, filters }: SummaryCardProps) {
           <span className="text-primary">FNGs:</span>
           <span>{renderStat(summary.fng_count, undefined, "FNGs")}</span>
         </div>
+        {/* Fart Sack King / Ghost King hidden from public view for now.
+            Calculations (summary.fartsack_kings / ghost_kings) still run upstream.
         <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
           <span className="text-primary flex items-center">
             Fart Sack King:
@@ -69,6 +76,7 @@ export function SummaryCard({ summary, filters }: SummaryCardProps) {
             <KingCell leaders={summary.ghost_kings} filters={filters} />
           </span>
         </div>
+        */}
         <div className="flex justify-between py-1 pb-2">
           <span className="text-primary">Average PAX:</span>
           <span>{renderStat(summary.pax_count_average, 2, "PAX")}</span>

--- a/src/components/area/SummaryCard.tsx
+++ b/src/components/area/SummaryCard.tsx
@@ -12,7 +12,8 @@ import { Divider } from "@heroui/divider";
 import { AreaSummary } from "@/lib/types";
 import { renderStat } from "@/lib/utils";
 import { HelpHint } from "@/components/HelpHint";
-import { KingCell } from "@/components/KingCell";
+// Fart Sack King / Ghost King hidden from public view for now.
+// import { KingCell } from "@/components/KingCell";
 
 type AreaSummaryCardProps = {
   summary: AreaSummary;
@@ -57,6 +58,8 @@ export function AreaSummaryCard({ summary }: AreaSummaryCardProps) {
           <span className="text-primary">FNGs:</span>
           <span>{renderStat(summary.fng_count, undefined, "FNGs")}</span>
         </div>
+        {/* Fart Sack King / Ghost King hidden from public view for now.
+            Calculations (summary.fartsack_kings / ghost_kings) still run upstream.
         <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
           <span className="text-primary flex items-center">
             Fart Sack King:
@@ -75,6 +78,7 @@ export function AreaSummaryCard({ summary }: AreaSummaryCardProps) {
             <KingCell leaders={summary.ghost_kings} />
           </span>
         </div>
+        */}
         <div className="flex justify-between py-1 pb-2">
           <span className="text-primary">Average PAX:</span>
           <span>{renderStat(summary.pax_count_average, 2, "PAX")}</span>

--- a/src/components/events.tsx
+++ b/src/components/events.tsx
@@ -230,8 +230,9 @@ export function EventsCard({
 
   // No-shows (signed up but didn't post). Lives in its own array so it never
   // mixes with the attendance roster or its counts.
-  const getFartsackList = (event: EventData) =>
-    sortAttendance(event.fartsacks ?? []);
+  // Hidden from public view for now — kept for easy restore.
+  // const getFartsackList = (event: EventData) =>
+  //   sortAttendance(event.fartsacks ?? []);
 
   // Client-side search across event, AO, region, PAX, and Q names, plus the
   // optional "As Q" gate that hides events this PAX did not Q (issue #115).
@@ -373,7 +374,8 @@ export function EventsCard({
                 const pax_list = getPaxList(event);
                 const q_list = getQList(event);
                 const coq_list = getcoQList(event);
-                const fartsack_list = getFartsackList(event);
+                // Fart Sackers hidden from public view for now.
+                // const fartsack_list = getFartsackList(event);
 
                 return (
                   <div key={event.event_instance_id || index}>
@@ -561,6 +563,9 @@ export function EventsCard({
                                       href={`/stats/pax/${pax.user_id}${filters ? `?${filters}` : ""}`}
                                       className="text-default-100"
                                     >
+                                      {/* Ghost styling hidden from public view
+                                          for now — ghosts render as normal chips.
+                                          (pax.ghost flag still computed upstream.) */}
                                       <Chip
                                         avatar={
                                           <Avatar
@@ -571,13 +576,6 @@ export function EventsCard({
                                         variant="bordered"
                                         color="default"
                                         size="sm"
-                                        // Ghosts (attended unannounced) get muted
-                                        // text — they posted, just off-plan.
-                                        classNames={{
-                                          content: pax.ghost
-                                            ? "text-default-400"
-                                            : "",
-                                        }}
                                       >
                                         {pax.f3_name ?? pax.user_id.toString()}
                                       </Chip>
@@ -598,8 +596,9 @@ export function EventsCard({
                             )}
                           </div>
                         </div>
-                        {/* Fart Sacks: signed up but no-showed. Separate labeled
-                            row, kept out of the attendee chips and counts. */}
+                        {/* Fart Sackers hidden from public view for now. The
+                            fartsack roster (event.fartsacks) is still computed
+                            upstream; only the display below is disabled.
                         {fartsack_list.length > 0 && (
                           <div className="flex flex-col gap-1 pb-2">
                             <span className="text-xs text-danger">
@@ -630,6 +629,7 @@ export function EventsCard({
                             </div>
                           </div>
                         )}
+                        */}
                       </CardBody>
                     </Card>
                   </div>

--- a/src/components/pax/SummaryCard.tsx
+++ b/src/components/pax/SummaryCard.tsx
@@ -42,6 +42,8 @@ export function SummaryCard({
               )}
             </span>
           </div>
+          {/* Ghost Events / Fart Sacked hidden from public view for now.
+              Calculations (summary.ghost_count / fartsack_count) still run upstream.
           <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
             <span className="text-primary flex items-center">
               Ghost Events:
@@ -68,6 +70,7 @@ export function SummaryCard({
               )}
             </span>
           </div>
+          */}
           <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
             <span className="text-primary">FNG Date:</span>
             <span>

--- a/src/components/region/SummaryCard.tsx
+++ b/src/components/region/SummaryCard.tsx
@@ -15,14 +15,18 @@ import { Divider } from "@heroui/divider";
 import { RegionSummary } from "@/lib/types";
 import { renderStat } from "@/lib/utils";
 import { HelpHint } from "@/components/HelpHint";
-import { KingCell } from "@/components/KingCell";
+// Fart Sack King / Ghost King hidden from public view for now.
+// import { KingCell } from "@/components/KingCell";
 
 type SummaryCardProps = {
   summary: RegionSummary;
   filters?: string;
 };
 
-export function SummaryCard({ summary, filters }: SummaryCardProps) {
+// `filters` stays in the props type (callers still pass it) but is unused while
+// the Fart Sack King / Ghost King rows are hidden; re-add it to the destructure
+// when restoring those rows.
+export function SummaryCard({ summary }: SummaryCardProps) {
   return (
     <Card className="bg-background/60 dark:bg-default-100/50" shadow="md">
       <CardHeader className="flex justify-between items-center px-6 lg:min-h-16">
@@ -58,6 +62,8 @@ export function SummaryCard({ summary, filters }: SummaryCardProps) {
           <span className="text-primary">FNGs:</span>
           <span>{renderStat(summary.fng_count, undefined, "FNGs")}</span>
         </div>
+        {/* Fart Sack King / Ghost King hidden from public view for now.
+            Calculations (summary.fartsack_kings / ghost_kings) still run upstream.
         <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10 text-sm">
           <span className="text-primary flex items-center">
             Fart Sack King:
@@ -76,6 +82,7 @@ export function SummaryCard({ summary, filters }: SummaryCardProps) {
             <KingCell leaders={summary.ghost_kings} filters={filters} />
           </span>
         </div>
+        */}
         <div className="flex justify-between py-1 pb-2 text-sm">
           <span className="text-primary">Average PAX:</span>
           <span>{renderStat(summary.pax_count_average, 2, "PAX")}</span>

--- a/src/components/sector/SummaryCard.tsx
+++ b/src/components/sector/SummaryCard.tsx
@@ -12,7 +12,8 @@ import { Divider } from "@heroui/divider";
 import { SectorSummary } from "@/lib/types";
 import { renderStat } from "@/lib/utils";
 import { HelpHint } from "@/components/HelpHint";
-import { KingCell } from "@/components/KingCell";
+// Fart Sack King / Ghost King hidden from public view for now.
+// import { KingCell } from "@/components/KingCell";
 
 type SectorSummaryCardProps = {
   summary: SectorSummary;
@@ -57,6 +58,8 @@ export function SectorSummaryCard({ summary }: SectorSummaryCardProps) {
           <span className="text-primary">FNGs:</span>
           <span>{renderStat(summary.fng_count, undefined, "FNGs")}</span>
         </div>
+        {/* Fart Sack King / Ghost King hidden from public view for now.
+            Calculations (summary.fartsack_kings / ghost_kings) still run upstream.
         <div className="flex justify-between py-1 pb-2 border-b light:border-black/10 dark:border-white/10">
           <span className="text-primary flex items-center">
             Fart Sack King:
@@ -75,6 +78,7 @@ export function SectorSummaryCard({ summary }: SectorSummaryCardProps) {
             <KingCell leaders={summary.ghost_kings} />
           </span>
         </div>
+        */}
         <div className="flex justify-between py-1 pb-2">
           <span className="text-primary">Average PAX:</span>
           <span>{renderStat(summary.pax_count_average, 2, "PAX")}</span>


### PR DESCRIPTION
### 👋 TL;DR

Temporarily hides all Fart Sack King / Ghost King (and related fartsack/ghost) UI from public view, while leaving every underlying calculation in place so it can be switched back on later.

### 🔎 Details

Hides everything fartsack/ghost-related from public display. No BigQuery/calculation logic was touched — the queries still compute `fartsack_kings`, `ghost_kings`, ghost flags, the `fartsacks` roster arrays, and `ghost_count` / `fartsack_count`. Only the rendering is disabled, and each hidden block is commented in place with a "hidden from public view for now" marker for easy restore.

- **Summary cards** (AO / Area / Region / Sector): hide the **Fart Sack King** and **Ghost King** rows.
- **PAX summary card**: hide the per-PAX **Ghost Events** and **Fart Sacked** count rows.
- **Recent event cards**: remove the **Fart Sackers** chip section and the ghost-specific muted-text styling — ghosts now render as normal PAX chips.
- **Event details view** (modal + standalone `/stats/events/[id]`): same fartsack/ghost display removed, for consistency with the cards it opens from.

Housekeeping: unused `KingCell` / `HelpHint` imports and now-unused helpers (`getFartsackList`, `fartsack_list`) were commented out to keep lint clean. In the AO and Region summary cards the `filters` prop is no longer consumed, so it was dropped from the destructure but kept in the props type (callers still pass it; a comment notes to re-add it when the King rows return).

### ✅ How to Test

1. `npm run typecheck`, `npm run lint`, and `npm test` all pass (109 tests).
2. Load an **AO / Area / Region / Sector** stats page → confirm no "Fart Sack King" or "Ghost King" rows in the summary card, and the remaining rows/borders look correct.
3. Load a **PAX** stats page → confirm no "Ghost Events" or "Fart Sacked" rows.
4. On any region/AO page, look at **Recent Events** cards → confirm there is no "Fart Sackers" section and that previously-ghosted attendees appear as normal (non-muted) chips.
5. Open an event's **View Details** modal and the standalone **Event Page** → confirm the same (no Fart Sackers section, ghosts render normally).

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
